### PR TITLE
KIWI-1321: Github Migrations - Post cleanup for F2F Front

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipv-cri-f2f-front repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @alphagov/di-ipv-kiwi-front-codeowners
+* @govuk-one-login/kiwi-front-codeowners
 
 # The following allows QA to review changes to /tests directory
 
-tests/ @alphagov/di-ipv-kiwi-qa-codeowners @alphagov/di-ipv-kiwi-front-codeowners
+tests/ @govuk-one-login/kiwi-qa-codeowners @govuk-one-login/kiwi-front-codeowners

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Proposed changes
 <!-- Provide a general summary of your changes in the Title above -->
-<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXXX] PR Title` -->
+<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
 
 ### What changed
 
@@ -15,7 +15,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXX)
+- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)
 
 ## Checklists
 


### PR DESCRIPTION
- Add the CODEOWNERS for new govuk-one-login github F2F Front

- [KIWI-1321](https://govukverify.atlassian.net/browse/KIWI-1321)


[KIWI-1321]: https://govukverify.atlassian.net/browse/KIWI-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ