### PR TITLE
[KIWI-1152] Updates support link

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Darganfyddwch fwy am gwcis"
   phaseBanner:
     tag: beta
-    content: Mae hwn yn wasanaeth newydd – bydd eich <a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
+    content: Mae hwn yn wasanaeth newydd – bydd eich <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
   footerNavItems:
     meta:
       items:
@@ -44,7 +44,7 @@ govuk:
           text: Telerau ac amodau
         - href: https://signin.account.gov.uk/privacy-notice
           text: Hysbysiad preifatrwydd
-        - href: https://signin.account.gov.uk/contact-us
+        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office
           text: Cymorth
   copyright:
     text: "© Hawlfraint y Goron"

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -6,7 +6,7 @@ error:
     description: Ewch yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.
     contactMeLink: Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)
     buttonText: Ewch i hafan GOV.UK
-    buttonLink: https://signin.account.gov.uk/contact-us?supportType=PUBLIC
+    buttonLink: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office
 
 pageNotFound:
   title: Tudalen heb ei darganfod
@@ -16,7 +16,7 @@ pageNotFound:
     - Os ydych wedi gludo'r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo'r cyfeiriad cyfan.
     - Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.
     - <a href=\"https://www.gov.uk/\" class=\"govuk-button\" data-module=\"govuk-button\">Ewch i hafan GOV.UK</a>
-    - <a href=\"https://signin.account.gov.uk/contact-us\" target=\"_blank\" class=\"govuk-link\">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
+    - <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office\" target=\"_blank\" class=\"govuk-link\">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
 
 sessionEnded:
   title: Sesiwn wedi dod i ben

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Find out more about cookies"
   phaseBanner:
     tag: beta
-    content: This is a new service – your <a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
+    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   footerNavItems:
     meta:
       items:
@@ -44,7 +44,7 @@ govuk:
           text: Terms and conditions
         - href: https://signin.account.gov.uk/privacy-notice
           text: Privacy notice
-        - href: https://signin.account.gov.uk/contact-us
+        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office
           text: Support
   copyright:
     text: "© Crown copyright"

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -6,7 +6,7 @@ error:
     description: Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     contactMeLink: Contact the GOV.UK One Login team (opens in new tab)
     buttonText: Go to the GOV.UK homepage
-    buttonLink: https://signin.account.gov.uk/contact-us?supportType=PUBLIC 
+    buttonLink: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office
 
 pageNotFound:
   title: Page not found
@@ -16,7 +16,7 @@ pageNotFound:
     - If you pasted the web address, check you copied the entire address.
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
-    - <a href="https://signin.account.gov.uk/contact-us" target="_blank" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office" target="_blank" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
 
 
 sessionEnded:

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -1,2 +1,27 @@
-<!-- Found in common folder -->
-{% extends "unrecoverable-error.njk" %}
+<!-- Copied from common express with contact link changed -->
+{% extends "base-page.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set hmpoPageKey = "error.unrecoverable" %}
+
+{% block mainContent %}
+  <h1 data-id="error-title">{{ translate("error.unrecoverable.title") }}</h1>
+
+  <p>{{ translate("error.unrecoverable.subTitle") }}</p>
+
+  <h2>{{ translate("error.unrecoverable.subHeading") }}</h2>
+
+  <div class="govuk-text">
+    <p>{{ translate("error.unrecoverable.description") }}</p>
+  </div>
+
+  {{ govukButton({
+    text: translate("error.unrecoverable.buttonText"),
+    href: translate("error.unrecoverable.buttonLink")
+  }) }}
+
+  <div>
+      <p><a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office\" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ translate("error.unrecoverable.contactMeLink") }}</a></p>
+  </div>
+
+{% endblock %}

--- a/src/views/f2f/error.html
+++ b/src/views/f2f/error.html
@@ -1,2 +1,1 @@
-<!-- Found in common folder -->
-{% extends "unrecoverable-error.njk" %}
+{% include "errors/error.html" %}


### PR DESCRIPTION
## Proposed changes

### What changed

Updates support link

### Why did it change

There is a new contact centre URL

### Screenshots

<img width="1792" alt="Screenshot 2023-10-31 at 10 02 15 am" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/40401118/f32fed9d-1099-4c42-8939-997126110825">
<img width="1792" alt="Screenshot 2023-10-31 at 10 06 28 am" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/40401118/5a1bc17a-3a40-41a1-a988-03d66a943db3">
<img width="1792" alt="Screenshot 2023-10-31 at 10 06 48 am" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/40401118/6b6ff5cc-4bcc-461f-9071-467e748c583f">
<img width="1792" alt="image" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/40401118/26f74e85-9c17-499f-975f-67b3b03771a8">


### Issue tracking

- [KIWI-1152](https://govukverify.atlassian.net/browse/KIWI-1152)


[KIWI-1152]: https://govukverify.atlassian.net/browse/KIWI-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ