### PR TITLE
KIWI-1486: Implement security rule for ALB

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,37 +128,37 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 524
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 526
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 525
+        "line_number": 527
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 528
+        "line_number": 530
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 530
+        "line_number": 532
       }
     ]
   },
-  "generated_at": "2023-12-15T15:51:49Z"
+  "generated_at": "2024-01-12T11:48:13Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -275,6 +275,8 @@ Resources:
             Value: !Ref AccessLogsBucket
           - Key: access_logs.s3.prefix
             Value: !Sub f2f-front-${Environment}
+          - Key: routing.http.drop_invalid_header_fields.enabled
+            Value: true
         - !Ref AWS::NoValue
 
   LoadBalancerListenerTargetGroupECS:


### PR DESCRIPTION
## Proposed changes

AWS Security compliance to add security rule for load balance

### What changed

Enabled alb-http-drop-invalid-header-enabled set to true

### Why did it change

Security Compliance recommendation

### Issue tracking

- [KIWI-1486](https://govukverify.atlassian.net/browse/KIWI-1486)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->

[KIWI-1486]: https://govukverify.atlassian.net/browse/KIWI-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ