### PR TITLE
[KIWI-1532] - F2F | FE | Subtext and Copy Changes to Document Selection Screen

### DIFF
--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -11,8 +11,8 @@ photoIdChoice:
       hint: Rhaid i'r cyfeiriad ar eich trwydded yrru fod yr un fath â'ch cyfeiriad presennol.
       reveal: ""
     brp:
-      label: Trwydded breswylio biometrig (BRP)
-      hint: ""
+      label: Trwydded breswylio biometrig y DU
+      hint: Efallai y bydd gennych BRP os oes gennych fisa am fwy na 6 mis neu ganiatâd amhenodol i aros. Ni allwch ddefnyddio Trwydded Gweithwyr Ffiniol y DU (FWP) na cherdyn preswylio biometrig y DU (BRC), a elwir hefyd yn gerdyn preswylio yn y DU.
       reveal: ""
     nonUkPassport:
       label: Pasbort o'r tu allan i'r DU

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -11,7 +11,7 @@ photoIdChoice:
       hint: Rhaid i'r cyfeiriad ar eich trwydded yrru fod yr un fath â'ch cyfeiriad presennol.
       reveal: ""
     brp:
-      label: Trwydded breswylio biometrig y DU
+      label: Trwydded breswylio biometrig y DU (BRP)
       hint: Efallai y bydd gennych BRP os oes gennych fisa am fwy na 6 mis neu ganiatâd amhenodol i aros. Ni allwch ddefnyddio Trwydded Gweithwyr Ffiniol y DU (FWP) na cherdyn preswylio biometrig y DU (BRC), a elwir hefyd yn gerdyn preswylio yn y DU.
       reveal: ""
     nonUkPassport:

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -27,7 +27,7 @@ photoIdSelectionThinFile:
 
 photoIdSelection:
   title: "Dewiswch pa ID gyda llun y gallwch fynd i'r Swyddfa Bost"
-  content: "Mae'n rhaid i chi fynd a'r ddogfen ID gyda llun gwreiddiol, nid llungopi."
+  content: "Ni allwch ddefnyddio llungopi neu gopi digidol o'ch ID gyda llun."
   expiryWarning: "Mae'n rhaid bod cyfnod eich ID gyda llun heb fod wedi dod i ben."
 
 dateOfBirth:

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -11,8 +11,8 @@ photoIdChoice:
       hint: The address on your driving licence must be the same as your current address.
       reveal: ""
     brp:
-      label: Biometric residence permit (BRP)
-      hint: ""
+      label: UK biometric residence permit (BRP)
+      hint: You might have a BRP if you have a visa for longer than 6 months or indefinite leave to remain. You cannot use a UK Frontier Worker permit (FWP) or a UK biometric residence card (BRC), also called a UK residence card.
       reveal: ""
     nonUkPassport:
       label: Non-UK passport

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -27,7 +27,7 @@ photoIdSelectionThinFile:
 
 photoIdSelection:
   title: "Choose which photo ID you can take to a Post Office"
-  content: "You must take the original photo ID document, not a photocopy."
+  content: "You cannot use a photocopy or digital copy of your photo ID."
   expiryWarning: "Your photo ID must not have expired."
 
 dateOfBirth:

--- a/src/views/f2f/choose-photo-id-post-office.html
+++ b/src/views/f2f/choose-photo-id-post-office.html
@@ -33,8 +33,6 @@
           {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
       {% endcall %}
 
-      {% include "common/confirmIdentityAnotherWay.html" %}
-
   {% endblock %}
 
   {% block bodyEnd %}


### PR DESCRIPTION
### What changed

Minor revisions to BRP subtext and the page instructions, with Welsh translations added. Removed "I want to prove my identity another way" link.

### Why did it change

To make the instructions clearer to users in English and Welsh

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1532](https://govukverify.atlassian.net/browse/KIWI-1532)

## Checklists

![Screenshot 2024-01-18 at 16 04 46](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/117987734/8e9818e7-7e3c-4428-bb2a-c63a44f289ab)

![Screenshot 2024-01-18 at 16 05 05](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/117987734/0c096e0d-b139-4570-abed-96e95e3199e7)





[KIWI-1532]: https://govukverify.atlassian.net/browse/KIWI-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ