### PR TITLE
[KIWI-1637]- F2F | FE | Accessibility Audit | Format dates on CYA

### DIFF
--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -114,12 +114,12 @@ class CheckDetailsController extends DateController {
           expiryDate = req.form.values.eeaIdCardExpiryDate;
           address = req.form.values.eeaIdentityCardAddressCheck;
           req.sessionModel.set("countryCode", req.form.values.eeaIdentityCardCountrySelector);
-          req.sessionModel.set("country", res.locals.translate(`countries.${req.form.values.eeaIdentityCardCountrySelector}`))
+          req.sessionModel.set("country", res.locals.translate(`countries.${req.form.values.eeaIdentityCardCountrySelector}`));
           break;
         }
       }
 
-      req.sessionModel.set("idHasExpiryDate", idHasExpiryDate)
+      req.sessionModel.set("idHasExpiryDate", idHasExpiryDate);
       req.sessionModel.set("expiryDate", expiryDate);
       req.sessionModel.set("addressCheck", address);
       
@@ -129,13 +129,13 @@ class CheckDetailsController extends DateController {
       const addressCheck = req.sessionModel.get("addressCheck");
       const hasExpiryDate = req.sessionModel.get("idHasExpiryDate");
       const format = "YYYY-MM-DD";
-      const language = req.lng
+      const language = req.lng;
 
       locals.formattedExpiryDate = formatDate(expiryDate, format, language);
-      locals.idTranslatedString = res.locals.translate(`photoIdChoice.items.${idChoice}.label`)
-      locals.addressCheckTranslatedString = res.locals.translate(`${idChoice}AddressCheck.items.${addressCheck}.label`)
-      locals.hasExpiryDateTranslatedString = res.locals.translate(`idHasExpiryDate.items.${hasExpiryDate}.label`)
-      locals.countryTranslatedString = req.sessionModel.get("country")
+      locals.idTranslatedString = res.locals.translate(`photoIdChoice.items.${idChoice}.label`);
+      locals.addressCheckTranslatedString = res.locals.translate(`${idChoice}AddressCheck.items.${addressCheck}.label`);
+      locals.hasExpiryDateTranslatedString = res.locals.translate(`idHasExpiryDate.items.${hasExpiryDate}.label`);
+      locals.countryTranslatedString = req.sessionModel.get("country");
 
       locals.changeUrl = `/${changeUrl}`;
       locals.hasExpiryDate = hasExpiryDate;
@@ -146,7 +146,7 @@ class CheckDetailsController extends DateController {
     });
   }
   next() {
-    return '/done'
+    return '/done';
   }
   async saveValues(req, res, callback) {
     try {

--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -128,9 +128,10 @@ class CheckDetailsController extends DateController {
       const changeUrl = req.sessionModel.get("changeUrl");
       const addressCheck = req.sessionModel.get("addressCheck");
       const hasExpiryDate = req.sessionModel.get("idHasExpiryDate");
+      const format = "YYYY-MM-DD";
       const language = req.lng
 
-      locals.formattedExpiryDate = formatDate(expiryDate, language);
+      locals.formattedExpiryDate = formatDate(expiryDate, format, language);
       locals.idTranslatedString = res.locals.translate(`photoIdChoice.items.${idChoice}.label`)
       locals.addressCheckTranslatedString = res.locals.translate(`${idChoice}AddressCheck.items.${addressCheck}.label`)
       locals.hasExpiryDateTranslatedString = res.locals.translate(`idHasExpiryDate.items.${hasExpiryDate}.label`)

--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -128,8 +128,9 @@ class CheckDetailsController extends DateController {
       const changeUrl = req.sessionModel.get("changeUrl");
       const addressCheck = req.sessionModel.get("addressCheck");
       const hasExpiryDate = req.sessionModel.get("idHasExpiryDate");
+      const language = req.lng
 
-      locals.formattedExpiryDate = formatDate(expiryDate, "YYYY-MM-DD");
+      locals.formattedExpiryDate = formatDate(expiryDate, language);
       locals.idTranslatedString = res.locals.translate(`photoIdChoice.items.${idChoice}.label`)
       locals.addressCheckTranslatedString = res.locals.translate(`${idChoice}AddressCheck.items.${addressCheck}.label`)
       locals.hasExpiryDateTranslatedString = res.locals.translate(`idHasExpiryDate.items.${hasExpiryDate}.label`)

--- a/src/app/f2f/utils.js
+++ b/src/app/f2f/utils.js
@@ -1,20 +1,24 @@
 const moment = require("moment");
 const { validators } = require("hmpo-form-wizard/lib/validation");
 
-function formatDate(expiryDate, language) {
-  if (expiryDate) {
-    const dateTransform = new Date(expiryDate);
+function formatDate(date, format, language) {
+  const isValid = moment(date, format, true).isValid();
+
+  if (isValid) {
+    const dateTransform = new Date(date);
     let dateFormat = "en-GB";
-      if (language === "cy") {
-        dateFormat = "cy";
-      }
+    if (language === "cy") {
+      dateFormat = "cy";
+    }
     return dateTransform.toLocaleDateString(dateFormat, {
       day: "numeric",
       month: "long",
       year: "numeric",
     });
+  } else {
+    return "";
   }
-};
+}
 
 function beforeNow(_value, timePeriod, timeUnit) {
   let dateFormat = "YYYY-MM-DD";

--- a/src/app/f2f/utils.js
+++ b/src/app/f2f/utils.js
@@ -1,26 +1,20 @@
 const moment = require("moment");
 const { validators } = require("hmpo-form-wizard/lib/validation");
 
-/**
- * formatDate takes a date (e.g. '1994-05-26') and the format it is in (e.g. 'YYYY-MM-DD)
- * If this is a valid date, it returns a string of the date in DD MM YYYY format
- * If the date isn't valid (no input, empty string) then an empty string is returned
- * @param date, @param string
- * @returns {string}
- */
-function formatDate(date, format) {
-  const isValid = moment(date, format,true).isValid();
-
-  if(isValid){
-    const check = moment(date, format);
-    const month = check.format('MM');
-    const day   = check.format('DD');
-    const year  = check.format('YYYY');
-    return day + ' ' + month + ' ' + year;
-  } else{
-    return ""
+function formatDate(expiryDate, language) {
+  if (expiryDate) {
+    const dateTransform = new Date(expiryDate);
+    let dateFormat = "en-GB";
+      if (language === "cy") {
+        dateFormat = "cy";
+      }
+    return dateTransform.toLocaleDateString(dateFormat, {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
   }
-}
+};
 
 function beforeNow(_value, timePeriod, timeUnit) {
   let dateFormat = "YYYY-MM-DD";

--- a/src/app/f2f/utils.test.js
+++ b/src/app/f2f/utils.test.js
@@ -3,27 +3,31 @@ const { expect } = require("chai");
 const moment = require("moment");
 
 
-describe('formatDate', () => {
-  it('returns a YYYY-MM-DD date with language set to en as DD Month(English) YYYY', () => {
-    expect(formatDate('2030-03-31', "en")).to.equal('31 March 2030');
-  })
+describe("formatDate", () => {
+  it("returns a YYYY-MM-DD date with language set to en as DD Month(English) YYYY", () => {
+    expect(formatDate("2030-03-31", "YYYY-MM-DD", "en")).to.equal(
+      "31 March 2030",
+    );
+  });
 
-  it('returns a YYYY-MM-DD date with language set to cy as DD Month(Welsh) YYYY', () => {
-    expect(formatDate('2030-03-31', "cy")).to.equal('31 Mawrth 2030');
-  })
+  it("returns a YYYY-MM-DD date with language set to cy as DD Month(Welsh) YYYY", () => {
+    expect(formatDate("2030-03-31", "YYYY-MM-DD", "cy")).to.equal(
+      "31 Mawrth 2030",
+    );
+  });
 
-  it('returns a YYYYMM/DD date as Invalid date', () => {
-    expect(formatDate('203003/31', "YYYY-MM-DD")).to.equal('Invalid Date');
-  })
+  it("returns a YYYYMM/DD date as an empty string", () => {
+    expect(formatDate("198903/31", "YYYY-MM-DD", "en")).to.equal("");
+  });
 
-  it('should return an empty string if date is empty string', () => {
-    expect(formatDate("", "YYYY-MM-DD")).to.equal(undefined);
-  })
+  it("should return an empty string if date is empty string", () => {
+    expect(formatDate("", "YYYY-MM-DD", "en")).to.equal("");
+  });
 
-  it('should return an empty string if date is empty', () => {
-    expect(formatDate(null, "YYYY-MM-DD")).to.equal(undefined);
-  })
-})
+  it("should return an empty string if date is empty", () => {
+    expect(formatDate(null, "YYYY-MM-DD", "en")).to.equal("");
+  });
+});
 
 describe('beforeNow', () => {
 

--- a/src/app/f2f/utils.test.js
+++ b/src/app/f2f/utils.test.js
@@ -4,20 +4,24 @@ const moment = require("moment");
 
 
 describe('formatDate', () => {
-  it('returns a YYYY-MM-DD date as DD MM YYYY', () => {
-    expect(formatDate('1989-03-31', "YYYY-MM-DD")).to.equal('31 03 1989');
+  it('returns a YYYY-MM-DD date with language set to en as DD Month(English) YYYY', () => {
+    expect(formatDate('1989-03-31', "en")).to.equal('31 March 1989');
   })
 
-  it('returns a YYYY-MM-DD date as DD MM YYYY', () => {
-    expect(formatDate('198903/31', "YYYY-MM-DD")).to.equal('');
+  it('returns a YYYY-MM-DD date with language set to cy as DD Month(Welsh) YYYY', () => {
+    expect(formatDate('1989-03-31', "cy")).to.equal('31 Mawrth 1989');
+  })
+
+  it('returns a YYYYMM/DD date as Invalid date', () => {
+    expect(formatDate('198903/31', "YYYY-MM-DD")).to.equal('Invalid Date');
   })
 
   it('should return an empty string if date is empty string', () => {
-    expect(formatDate("","YYYY-MM-DD")).to.equal("");
+    expect(formatDate("", "YYYY-MM-DD")).to.equal(undefined);
   })
 
   it('should return an empty string if date is empty', () => {
-    expect(formatDate(null,"YYYY-MM-DD")).to.equal("");
+    expect(formatDate(null, "YYYY-MM-DD")).to.equal(undefined);
   })
 })
 

--- a/src/app/f2f/utils.test.js
+++ b/src/app/f2f/utils.test.js
@@ -5,15 +5,15 @@ const moment = require("moment");
 
 describe('formatDate', () => {
   it('returns a YYYY-MM-DD date with language set to en as DD Month(English) YYYY', () => {
-    expect(formatDate('1989-03-31', "en")).to.equal('31 March 1989');
+    expect(formatDate('2030-03-31', "en")).to.equal('31 March 2030');
   })
 
   it('returns a YYYY-MM-DD date with language set to cy as DD Month(Welsh) YYYY', () => {
-    expect(formatDate('1989-03-31', "cy")).to.equal('31 Mawrth 1989');
+    expect(formatDate('2030-03-31', "cy")).to.equal('31 Mawrth 2030');
   })
 
   it('returns a YYYYMM/DD date as Invalid date', () => {
-    expect(formatDate('198903/31', "YYYY-MM-DD")).to.equal('Invalid Date');
+    expect(formatDate('203003/31', "YYYY-MM-DD")).to.equal('Invalid Date');
   })
 
   it('should return an empty string if date is empty string', () => {


### PR DESCRIPTION
### What changed

Changed formatDate function to format the user's chosen ID expiry date in the check answers page as DD Month YYYY, where month is either in English or Welsh depending on the language cookie.

### Why did it change

To reflect the outcome of the WCAG accessibility audit.

### Issue tracking

- [KIWI-1637](https://govukverify.atlassian.net/browse/KIWI-1637)

## Checklists

- [ /] Added screenshots to show the implementation is working

<img width="532" alt="Screenshot 2024-02-15 at 09 58 51" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/117987734/5d49e776-1afa-44d3-8a21-ca2caf61b04a">

<img width="520" alt="Screenshot 2024-02-15 at 09 58 38" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/117987734/f29aa0ff-20ba-4f75-8e36-e5b76cfe118c">


### Other considerations
<!-- Add any other consideration if needed -->


[KIWI-1637]: https://govukverify.atlassian.net/browse/KIWI-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ