### PR TITLE
Fixed serviceName yaml error

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -4,7 +4,7 @@ buttons:
   continue: Parhau
 
 govuk:
-  serviceName:
+  serviceName: ""
   backLink: Yn ôl
   errorSummaryTitle: Mae problem
   error: Gwall

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -4,7 +4,7 @@ buttons:
   continue: Continue
 
 govuk:
-  serviceName:
+  serviceName: ""
   backLink: Back
   errorSummaryTitle: There is a problem
   error: Error


### PR DESCRIPTION
### What changed

Added empty quote in English and Welsh default yaml files to remove error showing govuk.serviceName in screen title tag
