### PR TITLE
KIWI-1603: Add Support Manual URL pointing to FE Metrics Page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -114,51 +114,51 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 89
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 97
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 545
+        "line_number": 549
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 548
+        "line_number": 552
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 551
+        "line_number": 555
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 553
+        "line_number": 557
       }
     ]
   },
-  "generated_at": "2024-04-01T11:38:50Z"
+  "generated_at": "2024-04-11T10:56:02Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -43,6 +43,10 @@ Parameters:
     Type: Number
     Default: 0
     Description: Set to 1 to enable deployment of scaling infra in dev
+  SupportManualURL:
+    Description: "Link to the F2F support manual"
+    Type: String
+    Default: 'https://govukverify.atlassian.net/wiki/spaces/FTFCRI/pages/3623649281/F2F+FE+Metrics+Alerts'
   IPVStubStackName:
     Type: String
     Default: "f2f-ipv-stub"
@@ -411,7 +415,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ECSFatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs"
+      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -715,7 +719,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-APIGWFatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs"
+      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -847,7 +851,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"
-      AlarmDescription: Trigger the alarm if errorThreshold exceeds 10% with a minimum of 150 invocations and a minimum of 5 errors in 5 out of the last 5 minutes
+      AlarmDescription: !Sub "Trigger the warning alarm for Frontend 5XX Error ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -896,7 +900,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE4XXErrorAlarm"
-      AlarmDescription: Trigger the alarm if errorThreshold exceeds 5% with a minimum of 150 invocations and a minimum of 2 errors in 2 out of the last 5 minutes
+      AlarmDescription: !Sub "Trigger the warning alarm for Frontend 4xx Alarm ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -945,7 +949,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FELatencyAlarmP95"
-      AlarmDescription: Trigger the alarm if less than 95% of requests has a latency of less than 1 second with a minimum of 25 invocations in 2 out of the last 5 minutes
+      AlarmDescription: !Sub "Trigger the warning alarm for Frontend P95 Latency ${SupportManualURL}"
       ActionsEnabled: false
       OKActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -990,7 +994,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FELatencyAlarmP99"
-      AlarmDescription: Trigger the alarm if less than 99% of requests has a latency of less than 2.5 second with a minimum of 150 invocations in 2 out of the last 5 minutes
+      AlarmDescription: !Sub "Trigger the warning alarm for Frontend P99 Latency ${SupportManualURL}"
       ActionsEnabled: false
       OKActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -1038,7 +1042,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FELowContainerTaskCountAlarm"
-      AlarmDescription: Trigger a warning if the running container task count drops below 2
+      AlarmDescription: !Sub "Trigger a warning if the running container task count drops below 2 ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-critical-alert
@@ -1071,8 +1075,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FEHighContainerTaskCountWarning"
-      AlarmDescription: >-
-        Trigger a warning if the running container task count reaches the auto-scaling maximum for 5 minutes
+      AlarmDescription: !Sub "Trigger a warning if the running container task count reaches the auto-scaling maximum for 5 minutes ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -1107,7 +1110,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FELowContainerTaskCountCriticalAlarm"
-      AlarmDescription: Trigger a critical alert if the running container task count drops below 1
+      AlarmDescription: !Sub "Trigger a critical alert if the running container task count drops below 1 ${SupportManualURL}"
       ActionsEnabled: false  # to be enabled once proved stable in production
       AlarmActions:
         - !ImportValue platform-alarm-topic-critical-alert


### PR DESCRIPTION
## Proposed changes
Alarm description on the front end does not hold the support manual url. Add the support manual url to the alarm description and point to the FE Metrics page. 

### What changed
- Add Support Manual URL and point to the FE Metrics pages https://govukverify.atlassian.net/wiki/spaces/FTFCRI/pages/3623649281/F2F+FE+Metrics+Alerts
- Add Support manual description to Alarm descriptions

### Why did it change

To include the support url on the alarms

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1603](https://govukverify.atlassian.net/browse/KIWI-1603)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other
 consideration if needed -->

![Screenshot 2024-02-22 at 15 05 39](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/131283983/a4ea612b-94c2-4c68-9222-4145be688596)

[KIWI-1603]: https://govukverify.atlassian.net/browse/KIWI-1603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ