### PR TITLE
[KIWI-1526] Adding PII check-logs script for automated tests

### DIFF
--- a/check-logs.sh
+++ b/check-logs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+test_data="./test/browser/support/shared_claim.json"
+firstName=$(jq -r '.shared_claims.name[0].nameParts[0].value' "$test_data")
+firstName1=$(jq -r '.shared_claims.name[0].nameParts[1].value' "$test_data")
+lastName=$(jq -r '.shared_claims.name[0].nameParts[2].value' "$test_data")
+birthDate=$(jq -r '.shared_claims.birthDate[0].value' "$test_data")
+emailAddress=$(jq -r '.shared_claims.emailAddress' "$test_data")
+address_postalCode=$(jq -r '.shared_claims.address[0].postalCode' "$test_data")
+
+query="fields @timestamp, @message, @logStream, @log | filter @message like \"$firstName\" or @message like \"$firstName1\" or @message like \"$lastName\" or @message like \"$birthDate\" or @message like \"$emailAddress\" or @message like \"$address_postalCode\""
+
+echo $query
+
+stack_name="f2f-cri-front"
+log_groups=(
+    "/aws/ecs/$stack_name-F2FFront-ECS"
+)
+
+current_epoch=$(date +%s)
+fifteen_mins_ago_epoch=$((current_epoch - (15 * 60)))
+
+start_time=$fifteen_mins_ago_epoch
+end_time=$current_epoch
+
+query_id=$(aws logs start-query \
+    --log-group-names "${log_groups[@]}" \
+    --start-time "$start_time" \
+    --end-time "$end_time" \
+    --query-string "$query" \
+    --output text --query 'queryId')
+
+status="Running"
+while [ "$status" = "Running" ]; do
+    echo "Waiting for query to complete..."
+    sleep 1
+    query_status=$(aws logs get-query-results --query-id "$query_id")
+    status=$(echo "$query_status" | grep -o '"status": "[^"]*"' | cut -d '"' -f 4)
+done
+
+if echo "$query_status" | grep -q '"results": \[\]'; then
+    echo "Query found no PII 🎉"
+    exit 0
+else
+    echo "Query returned results:"
+    echo "$query_status" | jq -r '.results[] | @json'
+    exit 1
+fi

--- a/check-logs.sh
+++ b/check-logs.sh
@@ -8,9 +8,23 @@ birthDate=$(jq -r '.shared_claims.birthDate[0].value' "$test_data")
 emailAddress=$(jq -r '.shared_claims.emailAddress' "$test_data")
 address_postalCode=$(jq -r '.shared_claims.address[0].postalCode' "$test_data")
 
-query="fields @timestamp, @message, @logStream, @log | filter @message like \"$firstName\" or @message like \"$firstName1\" or @message like \"$lastName\" or @message like \"$birthDate\" or @message like \"$emailAddress\" or @message like \"$address_postalCode\""
+query="fields @timestamp, @message, @logStream, @log | filter @message like \"$firstName\""
 
-echo $query
+function update_query_string() {
+  # Get the array of search strings as arguments  
+  local searchStrings=("$@")
+
+  for value in "${searchStrings[@]}"
+  do
+    query+=" or @message like \"$value\""
+  done
+
+  # Return the updated query string
+  echo $query
+}
+
+updated_query=$(update_query_string $firstName1 $lastName $birthDate $emailAddress $address_postalCode)
+echo $updated_query
 
 stack_name="f2f-cri-front"
 log_groups=(

--- a/check-logs.sh
+++ b/check-logs.sh
@@ -23,8 +23,8 @@ function update_query_string() {
   echo $query
 }
 
-updated_query=$(update_query_string $firstName1 $lastName $birthDate $emailAddress $address_postalCode)
-echo $updated_query
+query=$(update_query_string $firstName1 $lastName $birthDate $emailAddress $address_postalCode)
+echo $query
 
 stack_name="f2f-cri-front"
 log_groups=(

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:browser:report": "node ./test/utils/multiReportGenerator.js",
     "test:e2e:cd:cucumber": "wait-on tcp:8090 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags \"@e2e or @browser\"",
     "test:e2e:cd": "npm-run-all -p -r mocks test:e2e:cd:cucumber && yarn run test:browser:report",
+    "test:pii": "bash ./check-logs.sh",
     "test:e2e": "cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @e2e",
 		"check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'"
   },

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,7 +17,17 @@ export TEST_HARNESS_URL=$(remove_quotes $CFN_F2FTestHarnessURL)
 export SESSION_TABLE=$(remove_quotes $CFN_BackendSessionTableName)
 export API_BASE_URL=$(remove_quotes "$CFN_F2FBackendURL")
 
+declare error_code
 
 cd /app; yarn run test:e2e:cd
+error_code=$?
 
 cp -rf /app/test/reports $TEST_REPORT_ABSOLUTE_DIR
+
+sleep 2m
+
+apt-get install jq -y
+cd /src; npm run test:pii
+error_code=$?
+
+exit $error_code

--- a/test/browser/support/shared_claim.json
+++ b/test/browser/support/shared_claim.json
@@ -5,7 +5,7 @@
           {
               "nameParts": [
                   {
-                      "value": "API",
+                      "value": "Kenneth",
                       "type": "GivenName"
                   },
                   {
@@ -13,7 +13,7 @@
                       "type": "GivenName"
                   },
                   {
-                      "value": "Test",
+                      "value": "Decerqueira",
                       "type": "FamilyName"
                   }
               ]


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Adding PII check-logs script to scan for PII data used for automated tests
Note that only shared_claim.json file is used for automated tests and other test data json files are used for staging tests.

### Why did it change

Catch PII in dev before deployment

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1526](https://govukverify.atlassian.net/browse/KIWI-1526)

Evidence of tests passing when no PII data is found for ref:
<img width="1069" alt="FE_result_pass" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/115095929/01d60773-8eb3-42e9-8f0c-5040687f21df">



[KIWI-1526]: https://govukverify.atlassian.net/browse/KIWI-1526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ