### PR TITLE
[KIWI-1714] - Update thin file user page

### DIFF
--- a/src/app/f2f/fields.js
+++ b/src/app/f2f/fields.js
@@ -27,8 +27,6 @@ module.exports = {
     hint: "",
     items: [
       { value: APP.PHOTO_ID_OPTIONS.UK_PASSPORT },
-      { value: APP.PHOTO_ID_OPTIONS.NON_UK_PASSPORT },
-      { divider: "or" },
       { value: APP.PHOTO_ID_OPTIONS.NO_PHOTO_ID },
     ],
     validate: ["required"],

--- a/src/app/f2f/steps.js
+++ b/src/app/f2f/steps.js
@@ -108,11 +108,6 @@ module.exports = {
       },
       {
         field: "photoIdChoice",
-        value: APP.PHOTO_ID_OPTIONS.NON_UK_PASSPORT,
-        next: APP.PATHS.NON_UK_PASSPORT_HAS_EXPIRY_DATE,
-      },
-      {
-        field: "photoIdChoice",
         value: APP.PHOTO_ID_OPTIONS.NO_PHOTO_ID,
         next: APP.PATHS.ABORT,
       },

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -25,7 +25,7 @@ module.exports = {
       F2F: "/",
       LANDING_PAGE: "/prove-identity-post-office",
       PHOTO_ID_SELECTION: "/choose-photo-id-post-office",
-      PHOTO_ID_SELECTION_THIN_FILE: "/choose-photo-id-post-office-biometric",
+      PHOTO_ID_SELECTION_THIN_FILE: "/do-you-have-UK-passport",
       UK_PASSPORT_DETAILS: "/uk-passport-expire",
       NON_UK_PASSPORT_DETAILS: "/non-uk-passport-expire",
       NON_UK_PASSPORT_HAS_EXPIRY_DATE: "/non-uk-passport-expiry-date",

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -33,18 +33,14 @@ photoIdChoice:
 
 photoIdChoiceThinFile:
   validation:
-    required: Dewiswch ID gyda llun y gallwch fynd i'r Swyddfa Bost
+    required: Dewiswch oes os oes gennych basbort y DU
   items:
     ukPassport:
-      label: Pasbort y DU
-      hint: Os yw'ch pasbort y DU wedi dod i ben, gallwch barhau i’w ddefnyddio i brofi pwy ydych chi hyd at 18 mis ar ôl ei ddyddiad dod i ben.
-      reveal: ""
-    nonUkPassport:
-      label: Pasbort o'r tu allan i'r DU gyda sglodyn biometrig
-      hint: Ni ddylai'ch pasbort fod wedi dod i ben.
+      label: Oes, mae gen i basbort y Deyrnas Unedig
+      hint: "Os yw'ch pasbort y DU wedi dod i ben, gallwch barhau i’w ddefnyddio i brofi pwy ydych chi hyd at 18 mis ar ôl ei ddyddiad dod i ben."
       reveal: ""
     noPhotoId:
-      label: Nid oes gennyf yr un o'r rhain
+      label: Na, nid oes gennyf basbort y Deyrnas Unedig
       reveal: ""
 
 "date-day":

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -19,11 +19,9 @@ landingPage:
       one: "Byddwch yn cael e-bost am ganlyniad eich gwiriad hunaniaeth - fel arfer o fewn diwrnod o fynd i'r Swyddfa Bost."
 
 photoIdSelectionThinFile:
-  title: "Dewiswch pa ID gyda llun y gallwch fynd i'r Swyddfa Bost"
-  content: "Yn seiliedig ar beth rydych wedi'i ddweud wrthym a'r gwiriadau rydym wedi'u gwneud, byddwch angen pasbort y DU neu basbort o'r tu allan i'r DU gyda sglodyn biometrig i brofi pwy ydych chi mewn Swyddfa Bost."
-  biometricHint: "I wirio a oes gan eich pasbort o'r tu allan i'r DU sglodyn biometrig, edrychwch am y symbol sglodyn biometrig petryal ar y clawr blaen."
-  biometricChipPhoto: <img src="public/images/biometricChipPhoto.png" alt="Llun Sglodyn Biometrig" width="150" height="100">
-  photocopyWarning: "Ni allwch ddefnyddio llungopi neu gopi digidol o'ch pasbort."
+  title: "Oes gennych chi basbort y Deyrnas Unedig?"
+  content: "Gallwch ddefnyddio unrhyw pasbort y DU. Os yw'ch pasbort y DU wedi dod i ben, gallwch barhau i'w ddefnyddio i brofi eich hunaniaeth hyd at 18 mis ar ôl ei ddyddiad dod i ben."
+  hint: "Ni allwch ddefnyddio llungopi neu gopi digidol o'ch pasbort."
 
 photoIdSelection:
   title: "Dewiswch pa ID gyda llun y gallwch fynd i'r Swyddfa Bost"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -33,18 +33,14 @@ photoIdChoice:
 
 photoIdChoiceThinFile:
   validation:
-    required: Choose a photo ID you can take to a Post Office
+    required: Select yes if you have a UK passport
   items:
     ukPassport:
-      label: UK passport
-      hint: If your UK passport has expired, you can still use it to prove your identity up to 18 months after its expiry date.
-      reveal: ""
-    nonUkPassport:
-      label: Non-UK passport with a biometric chip
-      hint: Your passport must not have expired.
+      label: Yes, I have a UK passport
+      hint: "If your UK passport has expired, you can still use it to prove your identity up to 18 months after its expiry date."
       reveal: ""
     noPhotoId:
-      label: I do not have either of these
+      label: No, I do not have a UK passport
       hint: ""
       reveal: ""
 

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -19,11 +19,9 @@ landingPage:
       one: "You'll get an email about the result of your identity check - usually within a day of going to the Post Office."
 
 photoIdSelectionThinFile:
-  title: "Choose which photo ID you can take to a Post Office"
-  content: "Based on what you've told us and the checks we've done, you’ll need a UK passport or a non-UK passport with a biometric chip to prove your identity at a Post Office."
-  biometricHint: "To check if your non-UK passport has a biometric chip, look for the rectangular biometric chip symbol on the front cover."
-  biometricChipPhoto: <img src="public/images/biometricChipPhoto.png" alt="Biometric Chip Photo" width="150" height="100">
-  photocopyWarning: "You cannot use a photocopy or digital copy of your passport."
+  title: "Do you have a UK passport?"
+  content: "If your UK passport has expired, you can still use it to prove your identity up to 18 months after its expiry date."
+  hint: "You cannot use a photocopy or digital copy of your passport. "
 
 photoIdSelection:
   title: "Choose which photo ID you can take to a Post Office"

--- a/src/views/components/countrySummaryListThinFileNoExpiry.njk
+++ b/src/views/components/countrySummaryListThinFileNoExpiry.njk
@@ -11,7 +11,7 @@
             actions: {
               items: [
                 {
-                  href: "/choose-photo-id-post-office-biometric/edit?edit=true",
+                  href: "/do-you-have-UK-passport/edit?edit=true",
                   text: translate("checkDetails.changeLink"),
                   visuallyHiddenText: translate("checkDetails.selectedId")
                 }

--- a/src/views/components/countryThinFileSummaryList.njk
+++ b/src/views/components/countryThinFileSummaryList.njk
@@ -11,7 +11,7 @@
             actions: {
               items: [
                 {
-                  href: "/choose-photo-id-post-office-biometric/edit?edit=true",
+                  href: "/do-you-have-UK-passport/edit?edit=true",
                   text: translate("checkDetails.changeLink"),
                   visuallyHiddenText: translate("checkDetails.selectedId")
                 }

--- a/src/views/components/ukPassportThinFileSummaryList.njk
+++ b/src/views/components/ukPassportThinFileSummaryList.njk
@@ -11,7 +11,7 @@
             actions: {
               items: [
                 {
-                  href: "/choose-photo-id-post-office-biometric/edit?edit=true",
+                  href: "/do-you-have-UK-passport/edit?edit=true",
                   text: translate("checkDetails.changeLink"),
                   visuallyHiddenText: translate("checkDetails.selectedId")
                 }

--- a/src/views/f2f/do-you-have-UK-passport.html
+++ b/src/views/f2f/do-you-have-UK-passport.html
@@ -9,10 +9,8 @@
 
     {% set title = translate("photoIdSelectionThinFile.title") %}
     {% set content = translate("photoIdSelectionThinFile.content") %}
-    {% set biometricHint = translate("photoIdSelectionThinFile.biometricHint") %}
-    {% set biometricChipPhoto = translate("photoIdSelectionThinFile.biometricChipPhoto") %}
-    {% set photocopyWarning = translate("photoIdSelectionThinFile.photocopyWarning") %}
-    {% set formInstructions = "<p>" + content + "</p><br><p>" + biometricHint + "</p><br><p>" + biometricChipPhoto + "</p><br><p>" + photocopyWarning + "</p>" %}
+    {% set hint = translate("photoIdSelectionThinFile.hint") %}
+    {% set formInstructions = "<br><p>" + content + "</p><br><p>" + hint + "</p>" %}
 
     {% call hmpoForm(ctx) %}
     {{ hmpoRadios(ctx, {


### PR DESCRIPTION
### What changed

Changed copy and removed non-UK biometric option from radio buttons on thin file selection page.

### Issue tracking

[KIWI-1714](https://govukverify.atlassian.net/browse/KIWI-1714)

[KIWI-1714]: https://govukverify.atlassian.net/browse/KIWI-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![image](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/118540036/292c3ba8-b9c6-4bf2-b779-5004a7123991)
![image](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/118540036/76d8ca1d-c259-472a-97d4-483482298740)
![image](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/118540036/20d8e074-b1d5-4ae8-aebd-457936e0150b)
![image](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/118540036/ca438521-338c-48fc-831b-76bddeed37ea)
