### PR TITLE
[KIWI-1798] - Remove the width limit on the error summary component

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -63,10 +63,6 @@ main p,
   @include govuk-responsive-margin(0, "bottom");
 }
 
-.govuk-error-summary {
-  width: 66.6666%;
-}
-
 #landingPageTitle {
   @include govuk-responsive-margin(5, "bottom");
 }


### PR DESCRIPTION
### What changed

Changed width of error summary component

### Why did it change

To align with GOV UK design system

### Issue tracking

- [KIWI-1798](https://govukverify.atlassian.net/browse/KIWI-1798)


[KIWI-1798]: https://govukverify.atlassian.net/browse/KIWI-1798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ