### PR TITLE
KIWI-1814- Update logic for change photoId journey

### DIFF
--- a/test/browser/features/BrowserBasedTests/UnhappyPath/CMAChangeButton/F2FCheckAnswersIDSelectionChange.feature
+++ b/test/browser/features/BrowserBasedTests/UnhappyPath/CMAChangeButton/F2FCheckAnswersIDSelectionChange.feature
@@ -1,40 +1,44 @@
-# @mock-api:f2f-f2f-success @success @browser
-# Feature: Change PhotoId - UnHappy Path
+@mock-api:f2f-f2f-success @success @browser
+Feature: Change PhotoId - UnHappy Path
 
 
-#     Background:
-#         Given A UK Drivers Licence User is using the system
-#         When they have provided their details
-#         Then they should be redirected to the Landing Page
+    Background:
+        Given A Non UK Passport User is using the system
+        When they have provided their details
+        Then they should be redirected to the Landing Page
 
-#         Given the user wants to progress to the next step of the journey
-#         When the user clicks the continue button on the Landing Page
-#         Then the user is routed to the next screen in the journey PhotoId Selection
+        Given the user wants to progress to the next step of the journey
+        When the user clicks the continue button on the Landing Page
+        Then the user is routed to the next screen in the journey PhotoId Selection
 
-#         Given the Other passport option is selected
-#         When the user clicks the continue button with Non UK passport selected
-#         Then the user is routed to the next screen - OtherPassport Details
+        Given the Other passport option is selected
+        When the user clicks the continue button with Non UK passport selected
+        Then the user is routed to the next screen - Non-UKPassportHasExpiryDate
 
-#         Given the date entered is within accepted Non UK expiration window
-#         When the user clicks the continue button on the Non UK passport page
-#         Then the user is routed to the Country of Issue Selector screen
+        When the user selects yes on the passport expiry date page
+        Then the user is routed to the next screen - OtherPassport Details
 
-#         Given the user is on the Country Code Selection screen
-#         When the user selects a country
-#         Then they are routed to the NonUKPassport Branch Finder screen
+        Given the date entered is within accepted Non UK expiration window
+        When the user clicks the continue button on the Non UK passport page
+        Then the user is routed to the Country of Issue Selector screen
 
-#         Given the postcode entered is valid
-#         When the user clicks the continue button on the find Post Office branch page
-#         Then the user is routed to the Select Location page showing 5 nearest POs
+        Given the user is on the Country Code Selection screen
+        When the user selects a country
+        Then they are routed to the NonUKPassport Branch Finder screen
 
-#         Given a Post Office branch is selected
-#         When the user clicks continue
-#         Then the user is navigated to the next step in the journey - Confirm Answer
+        Given the postcode entered is valid
+        When the user clicks the continue button on the find Post Office branch page
+        Then the user is routed to the Select Location page showing 5 nearest POs
 
-#      Scenario: Successful redirect from CMA screen back to the Doc Selection screen and back to CMA again
-#         Given the user has navigated to the Check My Answers Page
-#         When the user clicks the PhotoIdChange button
-#         Then the user is navigated back to the PhotoIdSelection page
-#         Then the user selects a new PhotoId Document 
-#         Then the user enters the PhotoId Expiry Date page 
-#         Then the user returns to the CMA page
+        Given a Post Office branch is selected
+        When the user clicks continue
+        Then the user is navigated to the next step in the journey - Confirm Answer
+
+     Scenario: Successful redirect from CMA screen back to the Doc Selection screen and back to CMA again
+        Given the user has navigated to the Check My Answers Page
+        When the user clicks the PhotoIdChange button
+        Then the user is navigated back to the PhotoIdSelection page
+        Then the user selects a new PhotoId Document 
+        And the user selects yes on the passport expiry date page
+        Then the user enters the PhotoId Expiry Date page 
+        Then the user returns to the CMA page


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Update logic for Change PhotoId - UnHappy Path test

- Uncomment test in F2FCheckAnswersIDSelectionChange.feature
- Add BDD step to fill out expiry date information for initial photoId choice (Non UK Passport) 
- Add BDD step to fill out expiry date information for second photoId choice (EU Drivers Licence) 

### Why did it change

Test feature file has been commented out for a while, test logic needed refactoring to get tests to pass. 
### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1814](https://govukverify.atlassian.net/browse/KIWI-1814)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1814]: https://govukverify.atlassian.net/browse/KIWI-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ