### PR TITLE
Kiwi 1726 qa

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "mocha",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "test:watch": "mocha --watch",
-    "test:browser": "cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browser",
+    "test:browser": "cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browsers",
     "test:browser:ci": "npm-run-all -p -r start:ci test:browser && npm run test:browser:report",
     "test:browser:report": "node ./test/utils/multiReportGenerator.js",
     "test:pii": "bash ./check-logs.sh",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "mocha",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "test:watch": "mocha --watch",
-    "test:browser": "cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browsers",
+    "test:browser": "cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browser",
     "test:browser:ci": "npm-run-all -p -r start:ci test:browser && npm run test:browser:report",
     "test:browser:report": "node ./test/utils/multiReportGenerator.js",
     "test:pii": "bash ./check-logs.sh",

--- a/test/browser/features/BrowserBasedTests/UnhappyPath/POLookup/F2FPostOfficeIncompleteData.feature
+++ b/test/browser/features/BrowserBasedTests/UnhappyPath/POLookup/F2FPostOfficeIncompleteData.feature
@@ -1,4 +1,4 @@
-@mock-api:f2f-f2f-success @browsers
+@mock-api:f2f-f2f-success @browser
 Feature: Handle Incomplete Data from Post Office API
 
     Scenario: User is successfully shown an error page when PO API returns incomplete data
@@ -19,4 +19,4 @@ Feature: Handle Incomplete Data from Post Office API
         Then the user is routed to the next screen in the journey Branch Finder Screen
         When the user enters a postcode that returns incomplete data
         And the user clicks the continue button on the find Post Office branch page
-        Then they should see the unrecoverable error page
+        Then they should see the IPV Core error page

--- a/test/browser/features/BrowserBasedTests/UnhappyPath/POLookup/F2FPostOfficeIncompleteData.feature
+++ b/test/browser/features/BrowserBasedTests/UnhappyPath/POLookup/F2FPostOfficeIncompleteData.feature
@@ -1,7 +1,7 @@
-@mock-api:f2f-f2f-success @browser
+@mock-api:f2f-f2f-success @browsers
 Feature: Handle Incomplete Data from Post Office API
 
-    Scenario: Successful redirect from CMA screen back to PO Finder then back to CMA screen
+    Scenario: User is successfully shown an error page when PO API returns incomplete data
         Given Authenticatable Anita is using the system
         When they have provided their details
         Then they should be redirected to the Landing Page
@@ -18,4 +18,5 @@ Feature: Handle Incomplete Data from Post Office API
         When the user clicks the continue button on the UKPassportPage
         Then the user is routed to the next screen in the journey Branch Finder Screen
         When the user enters a postcode that returns incomplete data
-
+        And the user clicks the continue button on the find Post Office branch page
+        Then they should see the unrecoverable error page

--- a/test/browser/features/BrowserBasedTests/UnhappyPath/POLookup/F2FPostOfficeIncompleteData.feature
+++ b/test/browser/features/BrowserBasedTests/UnhappyPath/POLookup/F2FPostOfficeIncompleteData.feature
@@ -1,0 +1,21 @@
+@mock-api:f2f-f2f-success @browser
+Feature: Handle Incomplete Data from Post Office API
+
+    Scenario: Successful redirect from CMA screen back to PO Finder then back to CMA screen
+        Given Authenticatable Anita is using the system
+        When they have provided their details
+        Then they should be redirected to the Landing Page
+
+        Given the user wants to progress to the next step of the journey
+        When the user clicks the continue button on the Landing Page
+        Then the user is routed to the next screen in the journey PhotoId Selection
+
+        Given the UK passport option is selected
+        When the user clicks the PhotoId continue button
+        Then the user is routed to the next screen in the journey Passport Details
+
+        Given the date entered is within accepted UK Passport expiration window
+        When the user clicks the continue button on the UKPassportPage
+        Then the user is routed to the next screen in the journey Branch Finder Screen
+        When the user enters a postcode that returns incomplete data
+

--- a/test/browser/pages/findBranch.js
+++ b/test/browser/pages/findBranch.js
@@ -29,6 +29,10 @@ module.exports = class PlaywrightDevPage {
     await this.page.locator("#postcode").fill("SW1A1AA");
   }
 
+  async postCodeIncompleteData() {
+    await this.page.locator("#postcode").fill("SW1A1MNE");
+  }
+
   async postCodeChange() {
     await this.page.locator("#postcode").fill("SW150TU");
   }

--- a/test/browser/pages/index.js
+++ b/test/browser/pages/index.js
@@ -31,6 +31,7 @@ module.exports = {
   BRPDetailsPageInvalidPast: require("./brpDetailsPageInvalidPast"),
   PhotoIdExpiryPage: require("./photoIdExpiryPage"),
   ErrorPage: require("./error.js"),
+  IpvErrorPage: require("./ipvError.js"),
   PassportDetailsPageValid: require("./ukPassportDetailsPageValid"),
   PassportDetailsPageValidEdit: require("./ukPassportDetailsPageValidEdit"),
   PassportDetailsPageInvalidFuture: require("./ukPassportDetailsPageInvalidFuture"),

--- a/test/browser/pages/ipvError.js
+++ b/test/browser/pages/ipvError.js
@@ -1,0 +1,32 @@
+module.exports = class PlaywrightDevPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+    this.path = "/redirect";
+  }
+
+  getErrorText() {
+    return this.page.textContent("body > pre");
+  }
+
+  getAuthorizationFailedMessage() {
+    return "Authorisation Grant Failed. See logs for details";
+  }
+
+  async isCurrentPage() {
+    const { pathname } = new URL(this.page.url());
+    return pathname === this.path;
+  }
+
+  async hasErrorQueryParams() {
+    const { searchParams } = new URL(this.page.url());
+
+    return (
+      searchParams.get("id") === "f2f" &&
+      searchParams.get("error") === "server_error" &&
+      searchParams.get("error_description") === "Failed"
+    );
+  }
+};

--- a/test/browser/pages/ipvError.js
+++ b/test/browser/pages/ipvError.js
@@ -7,14 +7,6 @@ module.exports = class PlaywrightDevPage {
     this.path = "/redirect";
   }
 
-  getErrorText() {
-    return this.page.textContent("body > pre");
-  }
-
-  getAuthorizationFailedMessage() {
-    return "Authorisation Grant Failed. See logs for details";
-  }
-
   async isCurrentPage() {
     const { pathname } = new URL(this.page.url());
     return pathname === this.path;

--- a/test/browser/step_definitions/F2FDocumentSelectionUKPassport.step.js
+++ b/test/browser/step_definitions/F2FDocumentSelectionUKPassport.step.js
@@ -66,3 +66,10 @@ Then(/^the user enters a valid postcode$/, async function () {
 
   await branchFinderPage.postCode();
 });
+
+
+When(/^the user enters a postcode that returns incomplete data$/, async function () {
+  const branchFinderPage = new FindBranch(await this.page);
+
+  await branchFinderPage.postCodeIncompleteData();
+});

--- a/test/browser/step_definitions/errors.js
+++ b/test/browser/step_definitions/errors.js
@@ -2,7 +2,7 @@ const { When, Then } = require("@cucumber/cucumber");
 
 const { expect } = require("chai");
 
-const { ErrorPage } = require("../pages");
+const { ErrorPage, IpvErrorPage } = require("../pages");
 
 When("there is an immediate error", () => {});
 
@@ -14,4 +14,15 @@ Then("they should see the unrecoverable error page", async function () {
   expect(errorTitle).to.equal(errorPage.getSomethingWentWrongMessage());
 
   expect(await errorPage.isCurrentPage()).to.be.true;
+});
+
+Then("they should see the IPV Core error page", async function () {
+  const ipvErrorPage = new IpvErrorPage(this.page);
+
+  const errorText = await ipvErrorPage.getErrorText();
+
+  expect(errorText).to.equal(ipvErrorPage.getAuthorizationFailedMessage());
+
+  expect(await ipvErrorPage.isCurrentPage()).to.be.true;
+  expect(await ipvErrorPage.hasErrorQueryParams()).to.be.true;
 });

--- a/test/browser/step_definitions/errors.js
+++ b/test/browser/step_definitions/errors.js
@@ -18,11 +18,7 @@ Then("they should see the unrecoverable error page", async function () {
 
 Then("they should see the IPV Core error page", async function () {
   const ipvErrorPage = new IpvErrorPage(this.page);
-
-  const errorText = await ipvErrorPage.getErrorText();
-
-  expect(errorText).to.equal(ipvErrorPage.getAuthorizationFailedMessage());
-
+  
   expect(await ipvErrorPage.isCurrentPage()).to.be.true;
   expect(await ipvErrorPage.hasErrorQueryParams()).to.be.true;
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

- New test added to check we're directed to IPV Core error page when a user enters a postCode that returns incomplete data from the Post Office API (postCode suffix = MNE) 
- New page object added to store IPV Core error validation logic 

### Why did it change

KIWI-1756 dev complete to improve the user journey when the PO API returns incomplete data for any reason

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1756](https://govukverify.atlassian.net/browse/KIWI-1756)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1756]: https://govukverify.atlassian.net/browse/KIWI-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ