### PR TITLE
KIWI-1863 - Abort Logic E2E Tests with DB Validation

### DIFF
--- a/test/browser/features/BrowserBasedTests/HappyPath/E2E/F2FEndToEnd.feature
+++ b/test/browser/features/BrowserBasedTests/HappyPath/E2E/F2FEndToEnd.feature
@@ -32,11 +32,11 @@ Feature: F2F Journey - E2E
         Then the user is navigated to the next step in the journey - Confirm Answer
         When the user clicks the Check My Answers Submit button
 
-        Given I have retrieved the sessionTable data for my F2F session
-        Then session details are correctly stored in DB
+        Given I have retrieved the sessionTable data for my F2F session using "authCode"
+        Then the authSessionState is correctly recorded as "F2F_AUTH_CODE_ISSUED"
         When I sent the request to the callback endpoint
         Then the Verifiable Credential is stored as expected
-        When I get all TxMA events from Test Harness
+        When I get 7 TxMA events from Test Harness
         Then the "F2F_CRI_START" event matches the "F2F_CRI_START_SCHEMA" Schema
         And the "F2F_YOTI_START" event matches the "F2F_YOTI_START_UK_DL" Schema
         And the "F2F_CRI_AUTH_CODE_ISSUED" event matches the "F2F_CRI_AUTH_CODE_ISSUED_SCHEMA" Schema
@@ -72,11 +72,11 @@ Feature: F2F Journey - E2E
         Then the user is navigated to the next step in the journey - Confirm Answer
         When the user clicks the Check My Answers Submit button
 
-        Given I have retrieved the sessionTable data for my F2F session
-        Then session details are correctly stored in DB
+        Given I have retrieved the sessionTable data for my F2F session using "authCode"
+        Then the authSessionState is correctly recorded as "F2F_AUTH_CODE_ISSUED"
         When I sent the request to the callback endpoint
         Then the Verifiable Credential is stored as expected
-        When I get all TxMA events from Test Harness
+        When I get 7 TxMA events from Test Harness
         Then the "F2F_CRI_START" event matches the "F2F_CRI_START_SCHEMA" Schema
         And the "F2F_YOTI_START" event matches the "F2F_YOTI_START_UK_PP" Schema
         And the "F2F_CRI_AUTH_CODE_ISSUED" event matches the "F2F_CRI_AUTH_CODE_ISSUED_SCHEMA" Schema
@@ -126,11 +126,11 @@ Feature: F2F Journey - E2E
         Then the user is navigated to the next step in the journey - Confirm Answer
         When the user clicks the Check My Answers Submit button
 
-        Given I have retrieved the sessionTable data for my F2F session
-        Then session details are correctly stored in DB
+        Given I have retrieved the sessionTable data for my F2F session using "authCode"
+        Then the authSessionState is correctly recorded as "F2F_AUTH_CODE_ISSUED"
         When I sent the request to the callback endpoint
         Then the Verifiable Credential is stored as expected
-        When I get all TxMA events from Test Harness
+        When I get 7 TxMA events from Test Harness
         Then the "F2F_CRI_START" event matches the "F2F_CRI_START_SCHEMA" Schema
         And the "F2F_YOTI_START" event matches the "F2F_YOTI_START_NON_UK_PP" Schema
         And the "F2F_CRI_AUTH_CODE_ISSUED" event matches the "F2F_CRI_AUTH_CODE_ISSUED_SCHEMA" Schema
@@ -165,11 +165,11 @@ Feature: F2F Journey - E2E
         Then the user is navigated to the next step in the journey - Confirm Answer
         When the user clicks the Check My Answers Submit button
 
-        Given I have retrieved the sessionTable data for my F2F session
-        Then session details are correctly stored in DB
+        Given I have retrieved the sessionTable data for my F2F session using "authCode"
+        Then the authSessionState is correctly recorded as "F2F_AUTH_CODE_ISSUED"
         When I sent the request to the callback endpoint
         Then the Verifiable Credential is stored as expected
-        When I get all TxMA events from Test Harness
+        When I get 7 TxMA events from Test Harness
         Then the "F2F_CRI_START" event matches the "F2F_CRI_START_SCHEMA" Schema
         And the "F2F_YOTI_START" event matches the "F2F_YOTI_START_BRP" Schema
         And the "F2F_CRI_AUTH_CODE_ISSUED" event matches the "F2F_CRI_AUTH_CODE_ISSUED_SCHEMA" Schema
@@ -215,11 +215,11 @@ Feature: F2F Journey - E2E
         Then the user is navigated to the next step in the journey - Confirm Answer
         When the user clicks the Check My Answers Submit button
 
-        Given I have retrieved the sessionTable data for my F2F session
-        Then session details are correctly stored in DB
+        Given I have retrieved the sessionTable data for my F2F session using "authCode"
+        Then the authSessionState is correctly recorded as "F2F_AUTH_CODE_ISSUED"
         When I sent the request to the callback endpoint
         Then the Verifiable Credential is stored as expected
-        When I get all TxMA events from Test Harness
+        When I get 7 TxMA events from Test Harness
         Then the "F2F_CRI_START" event matches the "F2F_CRI_START_SCHEMA" Schema
         And the "F2F_YOTI_START" event matches the "F2F_YOTI_START_EU_DL" Schema
         And the "F2F_CRI_AUTH_CODE_ISSUED" event matches the "F2F_CRI_AUTH_CODE_ISSUED_SCHEMA" Schema
@@ -265,11 +265,11 @@ Feature: F2F Journey - E2E
         Then the user is navigated to the next step in the journey - Confirm Answer
         When the user clicks the Check My Answers Submit button
 
-        Given I have retrieved the sessionTable data for my F2F session
-        Then session details are correctly stored in DB
+        Given I have retrieved the sessionTable data for my F2F session using "authCode"
+        Then the authSessionState is correctly recorded as "F2F_AUTH_CODE_ISSUED"
         When I sent the request to the callback endpoint
         Then the Verifiable Credential is stored as expected
-        When I get all TxMA events from Test Harness
+        When I get 7 TxMA events from Test Harness
         Then the "F2F_CRI_START" event matches the "F2F_CRI_START_SCHEMA" Schema
         And the "F2F_YOTI_START" event matches the "F2F_YOTI_START_EEA_ID_CARD" Schema
         And the "F2F_CRI_AUTH_CODE_ISSUED" event matches the "F2F_CRI_AUTH_CODE_ISSUED_SCHEMA" Schema
@@ -277,4 +277,20 @@ Feature: F2F Journey - E2E
         And the "F2F_YOTI_PDF_EMAILED" event matches the "F2F_YOTI_PDF_EMAILED_SCHEMA" Schema
         And the "F2F_YOTI_RESPONSE_RECEIVED" event matches the "F2F_YOTI_RESPONSE_RECEIVED_SCHEMA" Schema
         And the "F2F_CRI_VC_ISSUED" event matches the "F2F_CRI_VC_ISSUED_SCHEMA_EEA_ID_CARD" Schema
+
+    Scenario: F2F Journey - E2E Abort and DB Validation
+        Given A UK Drivers Licence User is using the system
+        When they have provided their details
+        Then they should be redirected to the Landing Page
+
+        Given the user wants to progress to the next step of the journey
+        When the user clicks the continue button on the Landing Page
+        Then the user is routed to the next screen in the journey PhotoId Selection
+        When the user selects I do not have any of these documents
+        And I have retrieved the sessionTable data for my F2F session using "state"
+        Then the authSessionState is correctly recorded as "F2F_CRI_SESSION_ABORTED"
+        When I get 2 TxMA events from Test Harness
+        Then the "F2F_CRI_START" event matches the "F2F_CRI_START_SCHEMA" Schema
+        And the "F2F_CRI_SESSION_ABORTED" event matches the "F2F_CRI_SESSION_ABORTED_SCHEMA" Schema
+
 

--- a/test/browser/pages/photoIdSelectionPage.js
+++ b/test/browser/pages/photoIdSelectionPage.js
@@ -45,6 +45,10 @@ module.exports = class PlaywrightDevPage {
     await this.page.click("#photoIdChoice-euPhotocardDl");
   }
 
+  async noDocumentAbortChoice() {
+    await this.page.click("#photoIdChoice-noPhotoId");
+  }
+
   async back() {
     await this.page.click("#back");
   }

--- a/test/browser/step_definitions/F2FBackendValidation.step.js
+++ b/test/browser/step_definitions/F2FBackendValidation.step.js
@@ -5,7 +5,6 @@ const { expect } = require("chai");
 const TestHarness = require("../support/TestHarness");
 
 const vcResponseData = require("../support/vcValidationData.json");
-const { error } = require("ajv/dist/vocabularies/applicator/dependencies");
 
 Given(
   "I have retrieved the sessionTable data for my F2F session using {string}",

--- a/test/browser/step_definitions/F2FLandingPage.step.js
+++ b/test/browser/step_definitions/F2FLandingPage.step.js
@@ -2,7 +2,7 @@ const { Given, When, Then } = require("@cucumber/cucumber");
 
 const { expect } = require("chai");
 
-const { LandingPage, PhotoIdSelectionPage } = require("../pages");
+const { LandingPage, PhotoIdSelectionPage, CheckDetails } = require("../pages");
 
 Given(
   /^the user wants to progress to the next step of the journey$/,
@@ -28,5 +28,19 @@ Then(
     const photoIdPage = new PhotoIdSelectionPage(await this.page);
 
     expect(await photoIdPage.isCurrentPage()).to.be.true;
+  }
+);
+
+Then(
+  /^the user selects I do not have any of these documents$/,
+  async function () {
+    const photoIdPage = new PhotoIdSelectionPage(await this.page);
+    const cmPage = new CheckDetails(await this.page);
+
+    await photoIdPage.noDocumentAbortChoice();
+    await photoIdPage.continue();
+
+    this.state = await cmPage.setSessionState();
+
   }
 );

--- a/test/browser/support/F2F_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/test/browser/support/F2F_CRI_SESSION_ABORTED_SCHEMA.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "event_name": {
+      "type": "string"
+    },
+    "user": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        },
+        "ip_address": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "user_id",
+        "session_id",
+        "ip_address"
+      ]
+    },
+    "timestamp": {
+      "type": "integer"
+    },
+    "event_timestamp_ms": {
+      "type": "integer"
+    },
+    "component_id": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "event_name",
+    "user",
+    "timestamp",
+    "event_timestamp_ms",
+    "component_id"
+  ]
+}

--- a/test/browser/support/F2F_CRI_START_SCHEMA.json
+++ b/test/browser/support/F2F_CRI_START_SCHEMA.json
@@ -35,25 +35,6 @@
         },
         "component_id": {
             "type": "string"
-        },
-        "restricted": {
-            "type": "object",
-            "properties": {
-              "device_information": {
-                "type": "object",
-                "properties": {
-                  "encoded": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "encoded"
-                ]
-              }
-            },
-            "required": [
-              "device_information"
-            ]
         }
     },
     "required": [
@@ -61,8 +42,7 @@
         "user",
         "timestamp",
         "event_timestamp_ms",
-        "component_id",
-        "restricted"
+        "component_id"
     ],
     "additionalProperties": false
 }

--- a/test/browser/support/F2F_CRI_START_SCHEMA.json
+++ b/test/browser/support/F2F_CRI_START_SCHEMA.json
@@ -35,6 +35,25 @@
         },
         "component_id": {
             "type": "string"
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+              "device_information": {
+                "type": "object",
+                "properties": {
+                  "encoded": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "encoded"
+                ]
+              }
+            },
+            "required": [
+              "device_information"
+            ]
         }
     },
     "required": [
@@ -42,7 +61,8 @@
         "user",
         "timestamp",
         "event_timestamp_ms",
-        "component_id"
+        "component_id",
+        "restricted"
     ],
     "additionalProperties": false
 }

--- a/test/browser/support/TestHarness.js
+++ b/test/browser/support/TestHarness.js
@@ -15,6 +15,7 @@ const F2F_YOTI_START_SCHEMA_02 = require("../support/F2F_YOTI_START_02_SCHEMA.js
 const F2F_YOTI_START_SCHEMA_03 = require("../support/F2F_YOTI_START_03_SCHEMA.json");
 const F2F_YOTI_START_SCHEMA_04 = require("../support/F2F_YOTI_START_04_SCHEMA.json");
 const F2F_YOTI_START_SCHEMA_05 = require("../support/F2F_YOTI_START_05_SCHEMA.json");
+const F2F_CRI_SESSION_ABORTED_SCHEMA = require("../support/F2F_CRI_SESSION_ABORTED_SCHEMA.json");
 const axios = require("axios");
 const aws4Interceptor = require("aws4-axios").aws4Interceptor;
 const { unmarshall } = require("@aws-sdk/util-dynamodb");
@@ -53,6 +54,7 @@ ajv.addSchema(F2F_YOTI_START_SCHEMA_02, "F2F_YOTI_START_NON_UK_PP");
 ajv.addSchema(F2F_YOTI_START_SCHEMA_03, "F2F_YOTI_START_BRP");
 ajv.addSchema(F2F_YOTI_START_SCHEMA_04, "F2F_YOTI_START_EU_DL");
 ajv.addSchema(F2F_YOTI_START_SCHEMA_05, "F2F_YOTI_START_EEA_ID_CARD");
+ajv.addSchema(F2F_CRI_SESSION_ABORTED_SCHEMA, "F2F_CRI_SESSION_ABORTED_SCHEMA");
 AjvFormats(ajv);
 
 module.exports = class TestHarness {
@@ -95,6 +97,17 @@ module.exports = class TestHarness {
     try {
       const getItemResponse = await this.HARNESS_API_INSTANCE.get(
         "/getSessionByAuthCode/" + process.env["SESSION_TABLE"] + "/" + authCode
+      );
+      return unmarshall(getItemResponse.data.Items[0]);
+    } catch (error) {
+      return error;
+    }
+  }
+
+  async getSessionByState(state) {
+    try {
+      const getItemResponse = await this.HARNESS_API_INSTANCE.get(
+        "/getSessionByState/" + process.env["SESSION_TABLE"] + "/" + state
       );
       return unmarshall(getItemResponse.data.Items[0]);
     } catch (error) {


### PR DESCRIPTION
## E2E Test Results

<img width="1690" alt="image" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/110032361/8ba73f30-4f25-48f5-882a-8b5fc56a1656">

## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Add E2E test to validate F2F Abort logic and validate to following:

- authSessionState = F2F_CRI_SESSION_ABORTED
- F2F_CRI_SESSION_ABORTED matched expected Schema

### Why did it change

Increase scope of E2E testing + support E2E testing of CloudFront changes.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1863](https://govukverify.atlassian.net/browse/KIWI-1863)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1863]: https://govukverify.atlassian.net/browse/KIWI-1863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ