### PR TITLE
KIWI-1868 - Cloudfront Header Updates

### DIFF
--- a/test/browser/support/F2F_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/test/browser/support/F2F_CRI_SESSION_ABORTED_SCHEMA.json
@@ -31,6 +31,25 @@
     },
     "component_id": {
       "type": "string"
+    },
+    "restricted": {
+      "type": "object",
+      "properties": {
+        "device_information": {
+          "type": "object",
+          "properties": {
+            "encoded": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "encoded"
+          ]
+        }
+      },
+      "required": [
+        "device_information"
+      ]
     }
   },
   "required": [
@@ -38,6 +57,8 @@
     "user",
     "timestamp",
     "event_timestamp_ms",
-    "component_id"
-  ]
+    "component_id",
+    "restricted"
+  ],
+  "additionalProperties": false
 }

--- a/test/browser/support/F2F_CRI_START_SCHEMA.json
+++ b/test/browser/support/F2F_CRI_START_SCHEMA.json
@@ -35,6 +35,25 @@
         },
         "component_id": {
             "type": "string"
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+              "device_information": {
+                "type": "object",
+                "properties": {
+                  "encoded": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "encoded"
+                ]
+              }
+            },
+            "required": [
+              "device_information"
+            ]
         }
     },
     "required": [
@@ -42,7 +61,8 @@
         "user",
         "timestamp",
         "event_timestamp_ms",
-        "component_id"
+        "component_id",
+        "restricted"
     ],
     "additionalProperties": false
 }

--- a/test/browser/support/F2F_YOTI_START_00_SCHEMA.json
+++ b/test/browser/support/F2F_YOTI_START_00_SCHEMA.json
@@ -157,11 +157,23 @@
                             ]
                         }
                     ]
+                },
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                      "encoded": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "encoded"
+                    ]
                 }
             },
             "required": [
                 "name",
-                "drivingPermit"
+                "drivingPermit",
+                "device_information"
             ]
         }
     },

--- a/test/browser/support/F2F_YOTI_START_01_SCHEMA.json
+++ b/test/browser/support/F2F_YOTI_START_01_SCHEMA.json
@@ -157,11 +157,23 @@
                             ]
                         }
                     ]
+                },
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                      "encoded": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "encoded"
+                    ]
                 }
             },
             "required": [
                 "name",
-                "passport"
+                "passport",
+                "device_information"
             ]
         }
     },

--- a/test/browser/support/F2F_YOTI_START_02_SCHEMA.json
+++ b/test/browser/support/F2F_YOTI_START_02_SCHEMA.json
@@ -157,11 +157,23 @@
                             ]
                         }
                     ]
+                },
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                      "encoded": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "encoded"
+                    ]
                 }
             },
             "required": [
                 "name",
-                "passport"
+                "passport",
+                "device_information"
             ]
         }
     },

--- a/test/browser/support/F2F_YOTI_START_03_SCHEMA.json
+++ b/test/browser/support/F2F_YOTI_START_03_SCHEMA.json
@@ -157,11 +157,23 @@
                             ]
                         }
                     ]
+                },
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                      "encoded": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "encoded"
+                    ]
                 }
             },
             "required": [
                 "name",
-                "residencePermit"
+                "residencePermit",
+                "device_information"
             ]
         }
     },

--- a/test/browser/support/F2F_YOTI_START_04_SCHEMA.json
+++ b/test/browser/support/F2F_YOTI_START_04_SCHEMA.json
@@ -157,11 +157,23 @@
                             ]
                         }
                     ]
+                },
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                      "encoded": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "encoded"
+                    ]
                 }
             },
             "required": [
                 "name",
-                "drivingPermit"
+                "drivingPermit",
+                "device_information"
             ]
         }
     },

--- a/test/browser/support/F2F_YOTI_START_05_SCHEMA.json
+++ b/test/browser/support/F2F_YOTI_START_05_SCHEMA.json
@@ -157,11 +157,23 @@
                             ]
                         }
                     ]
+                },
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                      "encoded": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "encoded"
+                    ]
                 }
             },
             "required": [
                 "name",
-                "idCard"
+                "idCard",
+                "device_information"
             ]
         }
     },


### PR DESCRIPTION
### E2E Test Results
<img width="1710" alt="image" src="https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/110032361/27522424-0a19-428c-a8a0-c2c6a15b6391">

### Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Update following TxMA JSON Schema to check for `restricted.device_information` field

- F2F_YOTI_START_XX_SCHEMA.json
- F2F_CRI_SESSION_ABORTED_SCHEMA.json
- F2F_CRI_START_SCHEMA.json

### Why did it change

Support testing of CloudFront changes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1868](https://govukverify.atlassian.net/browse/KIWI-1868)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1868]: https://govukverify.atlassian.net/browse/KIWI-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ