### PR TITLE
[KIWI-1919] - Hardcode PDF Preference in FE payload for DocumentSelection lambda

### DIFF
--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -213,6 +213,7 @@ class CheckDetailsController extends DateController {
           post_code: req.sessionModel.get("postOfficePostcode"),
           fad_code: req.sessionModel.get("postOfficeFadCode"),
         },
+        pdf_preference: "EMAIL_ONLY",
       };
 
       await this.saveF2fData(req.axios, f2fData, req);

--- a/src/app/f2f/controllers/checkDetails.test.js
+++ b/src/app/f2f/controllers/checkDetails.test.js
@@ -270,6 +270,7 @@ describe("CheckDetails controller", () => {
             post_code: req.sessionModel.get("postOfficePostcode"),
             fad_code: req.sessionModel.get("postOfficeFadCode"),
           },
+          pdf_preference: "EMAIL_ONLY",
         };
 
         await checkDetailsController.saveValues(req, res, next);


### PR DESCRIPTION
### What changed

pdf_preference property in front end payload sent to DocumentSelection lambda hardcoded to "EMAIL_ONLY"

### Why did it change

To avoid breaking the BE as pdfPreference is subject to a check which throws an error if failed

![Screenshot 2024-07-04 at 15 08 00 (2)](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/117987734/7de05991-f936-4ac2-b283-ab14ad69a136)

![Screenshot 2024-07-04 at 15 06 01 (2)](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/117987734/1f9d03e3-d7a6-405c-927d-4a6973101476)


![Screenshot 2024-07-04 at 15 05 55](https://github.com/govuk-one-login/ipv-cri-f2f-front/assets/117987734/e01c6dd1-188c-46de-bb15-c6860253ef59)



