### PR TITLE
[KIWI-1903]Fetching the feature flag from sessionConfig endpoint and storing it in the FE session store.

### DIFF
--- a/src/app/f2f/controllers/landingPage.js
+++ b/src/app/f2f/controllers/landingPage.js
@@ -12,9 +12,9 @@ class LandingPageController extends BaseController {
         // Show thin file user screen
         req.sessionModel.set("isThinFileUser", true);
       }
-      if (configData && configData.pcl_enabled) {
-        // Show the printed customer letter preference selection screen
-        req.sessionModel.set("pclEnabled", configData.pcl_enabled);
+      if (configData) {
+        // Save the printed customer letter enabled flag
+        req.sessionModel.set("pclEnabled", !!(configData.pcl_enabled == "true"));
       }
 
       super.saveValues(req, res, next);

--- a/src/app/f2f/controllers/landingPage.js
+++ b/src/app/f2f/controllers/landingPage.js
@@ -12,6 +12,10 @@ class LandingPageController extends BaseController {
         // Show thin file user screen
         req.sessionModel.set("isThinFileUser", true);
       }
+      if (configData && configData.pcl_enabled) {
+        // Show the printed customer letter preference selection screen
+        req.sessionModel.set("pclEnabled", configData.pcl_enabled);
+      }
 
       super.saveValues(req, res, next);
     } catch (err) {


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Fetching the feature flag from sessionConfig endpoint and storing it in the FE session store.

### Why did it change

Printed Customer Letter feature requirement. Need to check this flag before the PCL related screens are displayed to the User.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1903](https://govukverify.atlassian.net/browse/KIWI-1903)

Evidence of store saving this flag. For testing purpose only i had to console log out the value;
<img width="637" alt="Screenshot 2024-07-15 at 15 52 55" src="https://github.com/user-attachments/assets/c2b51a80-3ef0-4e8c-87a1-b459649b84d4">


[KIWI-1903]: https://govukverify.atlassian.net/browse/KIWI-1903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ