### PR TITLE
[KIWI-979] - F2F | PCL | FE | Create new screen for capturing customer PCL preference

### DIFF
--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -167,7 +167,7 @@ class CheckDetailsController extends DateController {
       req.sessionModel.set("expiryDate", expiryDate);
       req.sessionModel.set("addressCheck", address);
       req.sessionModel.set("pdfPreference", pdfPreference);
-      console.log("PDF VALUE", pdfPreference)
+
       //Confirmation display values
       const idChoice = req.sessionModel.get("photoIdChoice");
       const changeUrl = req.sessionModel.get("changeUrl");

--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -95,6 +95,8 @@ class CheckDetailsController extends DateController {
       let idHasExpiryDate;
       let expiryDate;
       let address;
+      const pdfPreference = req.form.values.postOfficeCustomerLetterChoice
+
       switch (req.form.values.photoIdChoice) {
         case APP.PHOTO_ID_OPTIONS.UK_PASSPORT: {
           expiryDate = req.form.values.ukPassportExpiryDate;
@@ -164,7 +166,8 @@ class CheckDetailsController extends DateController {
       req.sessionModel.set("idHasExpiryDate", idHasExpiryDate);
       req.sessionModel.set("expiryDate", expiryDate);
       req.sessionModel.set("addressCheck", address);
-
+      req.sessionModel.set("pdfPreference", pdfPreference);
+      console.log("PDF VALUE", pdfPreference)
       //Confirmation display values
       const idChoice = req.sessionModel.get("photoIdChoice");
       const changeUrl = req.sessionModel.get("changeUrl");
@@ -213,7 +216,7 @@ class CheckDetailsController extends DateController {
           post_code: req.sessionModel.get("postOfficePostcode"),
           fad_code: req.sessionModel.get("postOfficeFadCode"),
         },
-        pdf_preference: "EMAIL_ONLY",
+        pdf_preference: req.sessionModel.get("pdfPreference"),
       };
 
       await this.saveF2fData(req.axios, f2fData, req, res);

--- a/src/app/f2f/controllers/checkDetails.test.js
+++ b/src/app/f2f/controllers/checkDetails.test.js
@@ -278,7 +278,7 @@ describe("CheckDetails controller", () => {
             post_code: req.sessionModel.get("postOfficePostcode"),
             fad_code: req.sessionModel.get("postOfficeFadCode"),
           },
-          pdf_preference: "EMAIL_ONLY",
+          pdf_preference: req.sessionModel.get("pdfPreference"),
         };
 
         await checkDetailsController.saveValues(req, res, next);

--- a/src/app/f2f/controllers/landingPage.js
+++ b/src/app/f2f/controllers/landingPage.js
@@ -12,10 +12,6 @@ class LandingPageController extends BaseController {
         // Show thin file user screen
         req.sessionModel.set("isThinFileUser", true);
       }
-      if (configData) {
-        // Save the printed customer letter enabled flag
-        req.sessionModel.set("pclEnabled", !!(configData.pcl_enabled == "true"));
-      }
 
       super.saveValues(req, res, next);
     } catch (err) {

--- a/src/app/f2f/controllers/landingPage.js
+++ b/src/app/f2f/controllers/landingPage.js
@@ -5,6 +5,7 @@ const logger = require("hmpo-logger").get();
 class LandingPageController extends BaseController {
   async saveValues(req, res, next) {
     req.sessionModel.set("isThinFileUser", false);
+    req.sessionModel.set("pclEnabled", false);
 
     try {
       const configData = await this.getSessionConfig(req, res);

--- a/src/app/f2f/controllers/landingPage.js
+++ b/src/app/f2f/controllers/landingPage.js
@@ -12,6 +12,10 @@ class LandingPageController extends BaseController {
         // Show thin file user screen
         req.sessionModel.set("isThinFileUser", true);
       }
+      if (configData) {
+        // Save the printed customer letter enabled flag
+        req.sessionModel.set("pclEnabled", !!(configData.pcl_enabled == "true"));
+      }
 
       super.saveValues(req, res, next);
     } catch (err) {

--- a/src/app/f2f/fields.js
+++ b/src/app/f2f/fields.js
@@ -529,4 +529,23 @@ module.exports = {
       { type: "equal", fn: (value) => !value.match(/Select/) },
     ],
   },
+  postOfficeCustomerLetterChoice: {
+    legend: "",
+    label: "",
+    hint: "",
+    items: [
+      {
+        value: APP.POST_OFFICE_CUSTOMER_LETTER.EMAIL,
+        conditional: {
+          html: ""
+        }
+      },
+      { value: APP.POST_OFFICE_CUSTOMER_LETTER.POST,
+        conditional: {
+          html: ""
+        }
+      }
+    ],
+    validate: ["required"]
+  },
 };

--- a/src/app/f2f/steps.js
+++ b/src/app/f2f/steps.js
@@ -399,7 +399,18 @@ module.exports = {
     controller: resultsController,
     fields: ["branches"],
     revalidateIf: ["postcode", "branches"],
-    next: APP.PATHS.POST_OFFICE_CUSTOMER_LETTER,
+    next: [
+      {
+        field: "pclEnabled",
+        value: true,
+        next: APP.PATHS.POST_OFFICE_CUSTOMER_LETTER,
+      },
+      {
+        field: "pclEnabled",
+        value: false,
+        next: APP.PATHS.CHECK_DETAILS,
+      },
+    ],
   },
   [`${APP.PATHS.POST_OFFICE_CUSTOMER_LETTER}`]: {
     fields: ["postOfficeCustomerLetterChoice"],

--- a/src/app/f2f/steps.js
+++ b/src/app/f2f/steps.js
@@ -21,7 +21,7 @@ module.exports = {
     entryPoint: true,
     skip: true,
     controller: root,
-    next: APP.PATHS.LANDING_PAGE,
+    next: APP.PATHS.POST_OFFICE_CUSTOMER_LETTER,
   },
   [`${APP.PATHS.LANDING_PAGE}`]: {
     controller: landingPage,
@@ -399,7 +399,24 @@ module.exports = {
     controller: resultsController,
     fields: ["branches"],
     revalidateIf: ["postcode", "branches"],
-    next: APP.PATHS.CHECK_DETAILS,
+    next: APP.PATHS.POST_OFFICE_CUSTOMER_LETTER,
+  },
+  [`${APP.PATHS.POST_OFFICE_CUSTOMER_LETTER}`]: {
+    fields: ["postOfficeCustomerLetterChoice"],
+    editable: true,
+    editBackStep: APP.PATHS.CHECK_DETAILS,
+    next: [
+      {
+        field: "postOfficeCustomerLetterChoice",
+        value: APP.POST_OFFICE_CUSTOMER_LETTER.EMAIL,
+        next: APP.PATHS.CHECK_DETAILS
+      },
+      {
+        field: "postOfficeCustomerLetterChoice",
+        value: APP.POST_OFFICE_CUSTOMER_LETTER.POST,
+        next: APP.PATHS.CHECK_DETAILS
+      }
+    ]
   },
   [`${APP.PATHS.CHECK_DETAILS}`]: {
     controller: checkDetails,

--- a/src/app/f2f/steps.js
+++ b/src/app/f2f/steps.js
@@ -21,7 +21,7 @@ module.exports = {
     entryPoint: true,
     skip: true,
     controller: root,
-    next: APP.PATHS.POST_OFFICE_CUSTOMER_LETTER,
+    next: APP.PATHS.LANDING_PAGE,
   },
   [`${APP.PATHS.LANDING_PAGE}`]: {
     controller: landingPage,

--- a/src/app/f2f/steps.js
+++ b/src/app/f2f/steps.js
@@ -425,7 +425,7 @@ module.exports = {
       {
         field: "postOfficeCustomerLetterChoice",
         value: APP.POST_OFFICE_CUSTOMER_LETTER.POST,
-        next: APP.PATHS.CHECK_DETAILS
+        next: APP.PATHS.CHECK_ADDRESS
       }
     ]
   },

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -275,8 +275,6 @@ main p,
   @include govuk-responsive-margin(4, "bottom");
 }
 
-////
-
 .postOfficeLetterPrompt {
   color: govuk-colour("black");
   font-size: 24px;

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -274,3 +274,25 @@ main p,
 .govuk-warning-text {
   @include govuk-responsive-margin(4, "bottom");
 }
+
+////
+
+.postOfficeLetterPrompt {
+  color: govuk-colour("black");
+  font-size: 24px;
+  font-weight: bold;
+  @include govuk-responsive-margin(6, "top");
+  @include govuk-responsive-margin(3, "bottom");
+}
+
+#postOfficeCustomerLetterChoice-fieldset {
+  @include govuk-responsive-margin(4, "top");
+}
+
+#contentLine1 {
+  @include govuk-responsive-margin(5, "top");
+}
+
+#contentLine2 {
+  @include govuk-responsive-margin(6, "top");
+}

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -49,6 +49,7 @@ module.exports = {
       EXPIRED_ID: "/photo-id-expired",
       FIND_POST_OFFICE: "/find-post-office-prove-identity",
       CHOOSE_POST_OFFICE: "/choose-post-office-prove-identity",
+      POST_OFFICE_CUSTOMER_LETTER: "/post-office-customer-letter",
       CHECK_DETAILS: "/check-details",
       DONE: "/done",
       ERROR: "/error",
@@ -72,6 +73,10 @@ module.exports = {
     HAS_EXPIRY_DATE: {
       YES: "yes",
       NO: "no",
+    },
+    POST_OFFICE_CUSTOMER_LETTER: {
+      EMAIL: "email",
+      POST: "post"
     },
     PHOTO_ID_EXPIRY_OPTIONS: {
       RE_ENTER_DETAILS: "reEnterDetails",

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -458,7 +458,7 @@ countries:
 
 postOfficeCustomerLetterChoice:
   validation:
-    required: Select how you want to get you Post Office customer letter
+    required: Select how your want to get you Post Office customer letter
   content: ""
   items:
     email:

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -458,7 +458,7 @@ countries:
 
 postOfficeCustomerLetterChoice:
   validation:
-    required: Select how your want to get you Post Office customer letter
+    required: Select how you want to get your Post Office customer letter
   content: ""
   items:
     email:

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -455,3 +455,18 @@ countries:
     YEM: "Yemen"
     ZMB: "Zambia"
     ZWE: "Zimbabwe"
+
+postOfficeCustomerLetterChoice:
+  validation:
+    required: You must choose an option to continue
+  content: ""
+  items:
+    email:
+      label: Email only
+      hint: ""
+      reveal: ""
+    post:
+      label: Post and email
+      hint: "It can take up to 6 working days to get your letter by post."
+      reveal: ""
+   

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -458,7 +458,7 @@ countries:
 
 postOfficeCustomerLetterChoice:
   validation:
-    required: You must choose an option to continue
+    required: Select how you want to get you Post Office customer letter
   content: ""
   items:
     email:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -126,3 +126,9 @@ nonUkPassportCountrySelector:
   title: "Select which country your passport is from"
   content: "If the country your passport is from is not on the list, you'll need to choose another type of photo ID."
   link: "The country my passport is from is not on the list"
+
+postOfficeCustomerLetterChoice:
+  title: "Your Post Office customer letter"
+  content1: "We’ll send you a confirmation email with a link to download your Post Office customer letter."
+  content2: "We can also send your customer letter to you by post."
+  prompt: "How do you want to get your Post Office customer letter?"

--- a/src/views/f2f/post-office-customer-letter.html
+++ b/src/views/f2f/post-office-customer-letter.html
@@ -12,7 +12,7 @@
 {% set content1 = translate("postOfficeCustomerLetterChoice.content1") %}
 {% set content2 = translate("postOfficeCustomerLetterChoice.content2") %}
 {% set prompt = translate("postOfficeCustomerLetterChoice.prompt") %}
-{% set formInstructions = "<p>"+content1+"</p><br><p>"+content2+"</p><p class=\"expiredIdPrompt\">"+prompt+"</p>"%}
+{% set formInstructions = "<p id=\"contentLine1\">"+content1+"</p><p id=\"contentLine2\">"+content2+"</p><p class=\"postOfficeLetterPrompt\">"+prompt+"</p>"%}
       
       {% call hmpoForm(ctx) %}
               {{ hmpoRadios(ctx, {
@@ -22,7 +22,7 @@
                     legend: {
                         text: title,
                         isPageHeading: true,
-                        classes: "govuk-fieldset__legend--l idHasExpiryDate-radios"
+                        classes: "govuk-fieldset__legend--l postOfficeCustomerLetterChoice-radios"
                     }
                 },
                 hint: {

--- a/src/views/f2f/post-office-customer-letter.html
+++ b/src/views/f2f/post-office-customer-letter.html
@@ -1,0 +1,60 @@
+{% extends "base-form.njk" %}
+{# the content for this page is controlled by locales/en/default.yml #}
+{% set hmpoPageKey = "postOfficeCustomerLetter" %}
+{% set gtmJourney = "f2f - postOfficeCustomerLetter" %}
+
+{% from "hmpo-radios/macro.njk" import hmpoRadios %}
+{% from "hmpo-form/macro.njk" import hmpoForm %}
+
+{% block mainContent %}
+
+{% set title = translate("postOfficeCustomerLetterChoice.title") %}
+{% set content1 = translate("postOfficeCustomerLetterChoice.content1") %}
+{% set content2 = translate("postOfficeCustomerLetterChoice.content2") %}
+{% set prompt = translate("postOfficeCustomerLetterChoice.prompt") %}
+{% set formInstructions = "<p>"+content1+"</p><br><p>"+content2+"</p><p class=\"expiredIdPrompt\">"+prompt+"</p>"%}
+      
+      {% call hmpoForm(ctx) %}
+              {{ hmpoRadios(ctx, {
+                id: "postOfficeCustomerLetterChoice",
+                namePrefix: "postOfficeCustomerLetterChoice",
+                fieldset: {
+                    legend: {
+                        text: title,
+                        isPageHeading: true,
+                        classes: "govuk-fieldset__legend--l idHasExpiryDate-radios"
+                    }
+                },
+                hint: {
+                    html: formInstructions
+                }
+            }) }}
+
+    {{ hmpoSubmit(ctx, {id: "continue", classes: "radioButtonsContinue", text: translate("buttons.next")}) }}
+  
+    {% endcall %}
+
+{% endblock %} 
+
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+    <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
+        window.addEventListener('load', function () {
+            window
+                .DI
+                .analyticsGa4
+                .pageViewTracker
+                .trackOnPageLoad({
+                    statusCode: '200', // Access status code
+                    englishPageTitle: '{{translate("euDrivingLicenceHasExpiryDate.title")}}',
+                    taxonomy_level1: 'web cri', // Access taxonomy level 1
+                    taxonomy_level2: 'f2f', // Access taxonomy level 2
+                    content_id: '001',
+                    logged_in_status: true,
+                    dynamic: false
+                });
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
### What changed

New screen to capture user PDF preference

### Why did it change

So that users that want a instructions in the form of a posted letter in addition to email can make a request for one

### Issue tracking

- [KIWI-979](https://govukverify.atlassian.net/browse/KIWI-979)

![Screenshot 2024-07-18 at 11 25 59](https://github.com/user-attachments/assets/43869ce9-d012-49b1-b966-f38cc0d08e32)

![Screenshot 2024-07-18 at 11 48 20](https://github.com/user-attachments/assets/149bda23-8e97-4c70-9064-2abe82b7fd27)



[KIWI-979]: https://govukverify.atlassian.net/browse/KIWI-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ