### PR TITLE
KIWI-1947 TxMA JSON Schema Update

### DIFF
--- a/test/browser/support/F2F_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/test/browser/support/F2F_CRI_SESSION_ABORTED_SCHEMA.json
@@ -15,12 +15,16 @@
         },
         "ip_address": {
           "type": "string"
+        },
+        "govuk_signin_journey_id": {
+            "type": "string"
         }
       },
       "required": [
         "user_id",
         "session_id",
-        "ip_address"
+        "ip_address",
+        "govuk_signin_journey_id"
       ]
     },
     "timestamp": {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Add check for govuk_signin_journey_id in E2E test validating F2F_CRI_SESSION_ABORTED TxMA Event

### Why did it change

Missing govuk_signin_journey_id field added to F2F_CRI_SESSION_ABORTED TxMA event.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1947](https://govukverify.atlassian.net/browse/KIWI-1947)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1947]: https://govukverify.atlassian.net/browse/KIWI-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ