### PR TITLE
Updated hint text for radio buttons

### DIFF
--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -472,7 +472,7 @@ customerLetterCheckAddress:
     required: "Select if you want you Post Office customer letter to be sent to this address"
   items:
     existingAddress:
-      label: "Yes"
+      label: "Yes, I want my customer letter to be sent to this address"
       hint: ""
       reveal: ""
     differentAddress:
@@ -487,7 +487,7 @@ postOfficeCustomerLetterChoice:
   items:
     email:
       label: Email only
-      hint: ""
+      hint: "You can show your letter on your phone or tablet, or take a printed copy with you."
       reveal: ""
     post:
       label: Post and email


### PR DESCRIPTION
### What changed

Added missing hint text for radio buttons on printed customer letter screens

### Issue tracking 

[KIWI-2104](https://govukverify.atlassian.net/browse/KIWI-2104)


<img width="701" alt="Screenshot 2024-12-11 at 09 10 44" src="https://github.com/user-attachments/assets/931df28c-0275-4840-be0e-f5d72448e9ef">
<img width="705" alt="Screenshot 2024-12-11 at 09 11 02" src="https://github.com/user-attachments/assets/4b181cde-6b83-49cc-a969-ce1494a209ad">


[KIWI-2104]: https://govukverify.atlassian.net/browse/KIWI-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ