### PR TITLE
[KIWI-XXXX] - Update formatting rules for address received in shared_claims

### DIFF
--- a/src/app/f2f/controllers/checkAddress.js
+++ b/src/app/f2f/controllers/checkAddress.js
@@ -3,10 +3,9 @@ const { Controller: BaseController } = require("hmpo-form-wizard");
 class CheckAddressController extends BaseController {
   locals(req, res, callback) {
     super.locals(req, res, (err, locals) => {
-      locals.addressLine1 = req.sessionModel.get("addressLine1");
-      locals.addressLine2 = req.sessionModel.get("addressLine2");
-      locals.townCity = req.sessionModel.get("townCity");
-      locals.postalCode = req.sessionModel.get("postalCode");
+      locals.addressLine = req.sessionModel.get(
+        "fullParsedSharedClaimsAddress"
+      );
       callback(err, locals);
     });
   }

--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -186,13 +186,10 @@ class CheckDetailsController extends DateController {
         );
         locals.addressLine = displayAddress;
       } else {
-        locals.addressLine = `${req.sessionModel.get(
-          "addressLine1"
-        )}<br>${req.sessionModel.get("addressLine2")}<br>${req.sessionModel.get(
-          "townCity"
-        )}</br>${req.sessionModel.get("postalCode")}`;
+        locals.addressLine = req.sessionModel.get(
+          "fullParsedSharedClaimsAddress"
+        );
       }
-
       if (req.sessionModel.get("postOfficeCustomerLetterChoice") == "email") {
         locals.pdfPreferenceText = res.locals.translate(
           "checkDetails.pdfPreferenceTextEmail"

--- a/src/app/f2f/controllers/root.js
+++ b/src/app/f2f/controllers/root.js
@@ -18,10 +18,29 @@ class RootController extends BaseController {
         const userAddress = decryptKey.decrypt(encryptedJSON, "utf8");
         const parsedAddress = JSON.parse(userAddress);
 
-        req.sessionModel.set("addressLine1", parsedAddress["address_line1"]);
-        req.sessionModel.set("addressLine2", parsedAddress["address_line2"]);
-        req.sessionModel.set("townCity", parsedAddress["town_city"]);
-        req.sessionModel.set("postalCode", parsedAddress["postal_code"]);
+        let addressParts = [];
+        if (parsedAddress["address_line1"]) {
+          addressParts.push(parsedAddress["address_line1"]);
+        }
+        if (parsedAddress["address_line2"]) {
+          addressParts.push(parsedAddress["address_line2"]);
+        }
+        if (parsedAddress["town_city"]) {
+          addressParts.push(parsedAddress["town_city"]);
+        }
+        if (parsedAddress["postal_code"]) {
+          addressParts.push(parsedAddress["postal_code"]);
+        }
+        const fullParsedSharedClaimsAddress = addressParts.join("<br>");
+        req.sessionModel.set(
+          "fullParsedSharedClaimsAddress",
+          fullParsedSharedClaimsAddress
+        );
+
+        // req.sessionModel.set("addressLine1", parsedAddress["address_line1"]);
+        // req.sessionModel.set("addressLine2", parsedAddress["address_line2"]);
+        // req.sessionModel.set("townCity", parsedAddress["town_city"]);
+        // req.sessionModel.set("postalCode", parsedAddress["postal_code"]);
         req.sessionModel.set("addressProcessed", true);
       } catch (error) {
         logger.error("Error calling /person-info", error);

--- a/src/views/f2f/post-office-customer-letter-check-address.html
+++ b/src/views/f2f/post-office-customer-letter-check-address.html
@@ -11,7 +11,7 @@
 {% set title = translate("customerLetterCheckAddress.title") %}
 {% set content = translate("customerLetterCheckAddress.content") %}
 {% set prompt = translate("customerLetterCheckAddress.prompt") %}
-{% set sharedClaimsAddress = "<p>"+addressLine1+"</p><p>"+addressLine2+"</p><p>"+townCity+"</p><p>"+postalCode+"</p>" %}
+{% set sharedClaimsAddress = "<p>"+addressLine+"</p>" %}
 {% set insetText = govukInsetText({
     html: sharedClaimsAddress
   }) %}


### PR DESCRIPTION
### What changed

Update formatting rules for address received in shared_claims to account for cases where address is missing values

### Why did it change

To ensure correct display format for addresses

### Evidence - before and after
![Screenshot 2025-02-03 at 11 53 40](https://github.com/user-attachments/assets/3ec0afce-7986-4e15-872a-d0e24526a9cd)
![Screenshot 2025-02-03 at 12 24 17](https://github.com/user-attachments/assets/a53bddbb-d37b-4e60-90e9-30b3ec8cd1c3)
