### PR TITLE
[KIWI-2149] - Address UCD design review comments

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -260,6 +260,8 @@ main p,
 }
 
 #letterPostcode-label {
+  font-weight: bold;
+  font-size: 23px;
   @include govuk-responsive-margin(3, "bottom");
 }
 

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -133,12 +133,6 @@ main p,
   margin-right: 6px;
 }
 
-#postcode-label {
-  font-weight: bold;
-  font-size: 23px;
-  @include govuk-responsive-margin(3, "bottom");
-}
-
 #landingPageContinue {
   @include govuk-responsive-margin(1, "top");
 }
@@ -255,7 +249,21 @@ main p,
   @include govuk-responsive-margin(0, "bottom");
 }
 
+#postcode-label {
+  font-weight: bold;
+  font-size: 23px;
+  @include govuk-responsive-margin(3, "bottom");
+}
+
 #postcode-hint {
+  @include govuk-responsive-margin(4, "bottom");
+}
+
+#letterPostcode-label {
+  @include govuk-responsive-margin(3, "bottom");
+}
+
+#letterPostcode-hint {
   @include govuk-responsive-margin(4, "bottom");
 }
 

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -73,7 +73,7 @@ common:
   postoffice:
     service: "Nid yw pob Swyddfa Bost yn cynnig y gwasanaeth hwn. Gallwch"
     postofficeLink: "Swyddfa Bost sy'n cynnig dilysu mewn canghennau (agor mewn tab newydd)."
-    pathToPoBranchSearch: "https://www.postoffice.co.uk/identity/in-branch-verification-service#bf-full-width"
+    pathToPoBranchSearch: "https://www.postoffice.co.uk/identity/in-branch-verification-service#bfSearchLabel"
   photoIdSelection:
     noPhotoId: "Nid oes gennyf unrhyw un o'r dogfennau hyn"
     linkToNoPhotoId: "https://signin.account.gov.uk/no-photo-id"

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -193,9 +193,8 @@ postcode:
     default: "Rhowch god post gwirioneddol yn y DU"
 
 letterPostcode:
-  legend: ""
-  label: ""
-  hint: ""
+  label: Cod post y DU
+  hint: Er enghraifft, SW1A 2AA
   validation:
     default: "Rhowch god post llawn yn y DU"
 

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -91,9 +91,6 @@ photoIdExpiry:
 findAddress:
   title: "Dod o hyd i gyfeiriad"
   content: "Rhowch god post y DU ble rydych am gael llythyr cwsmer Swyddfa'r Post wedi'i anfon."
-  prompt: "Cod post y DU"
-  hintText: "Er enghraifft, SW1A 2AA"
-  link: "Rhowch gyfeiriad â llaw"
 
 checkDetails:
   title: "Edrychwch dros eich atebion"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -73,7 +73,7 @@ common:
     postoffice:
       service: "Not all Post Offices offer this service. You can "
       postofficeLink: "Post Office that offers in-branch verification (opens in new tab)."
-      pathToPoBranchSearch: "https://www.postoffice.co.uk/identity/in-branch-verification-service#bf-full-width"
+      pathToPoBranchSearch: "https://www.postoffice.co.uk/identity/in-branch-verification-service#bfSearchLabel"
     photoIdSelection:
       noPhotoId: "I do not have any of these documents"
       linkToNoPhotoId: "https://signin.account.gov.uk/no-photo-id"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -196,9 +196,8 @@ postcode:
     default: "Enter a real UK postcode"
 
 letterPostcode:
-  legend: ""
-  label: ""
-  hint: ""
+  label: UK postcode
+  hint: For example, SW1A 2AA
   validation:
     default: "Enter a full UK postcode"
 

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -3,7 +3,7 @@ landingPage:
   firstCircle: "1"
   firstStepTitle: "Get your Post Office customer letter from GOV.UK"
   secondCircle: "2"
-  secondStepTitle: "Go to the Post Office"
+  secondStepTitle: "Go to a Post Office"
   thirdCircle: "3"
   thirdStepTitle: "Wait for your result"
   instructions:
@@ -76,6 +76,10 @@ locations:
   content: "Your chosen Post Office will be shown on your customer letter. You can go to a different Post Office as long as it offers in-branch verification."
   body: "Postcode"
 
+findAddress:
+  title: "Find an address"
+  content: "Enter the UK postcode of where you want to have your Post Office customer letter sent."
+
 addressResults:
   title: "Choose an address"
   label: "Postcode"
@@ -87,13 +91,6 @@ photoIdExpiry:
   title: "Your photo ID has expired"
   content: "You need valid photo ID to prove your identity."
   prompt: "What would you like to do?"
-
-findAddress:
-  title: "Find an address"
-  content: "Enter the UK postcode of where you want to have your Post Office customer letter sent."
-  prompt: "UK postcode"
-  hintText: "For example, SW1A 2AA"
-  link: "Enter address manually"
 
 checkDetails:
   title: "Check your answers"
@@ -108,7 +105,7 @@ checkDetails:
   country: Country
   hasExpiryDate: Does your photo ID have an expiry date?
   pdfPreference: How do you want to get your Post Office customer letter?
-  pdfChosenAddress: Where your post office customer letter will be sent
+  pdfChosenAddress: Where your Post Office customer letter will be sent
   pdfPreferenceTextEmail: "By email only"
   pdfPreferenceTextPcl: "By email and post"
 

--- a/src/views/f2f/post-office-customer-letter-find-address.html
+++ b/src/views/f2f/post-office-customer-letter-find-address.html
@@ -4,39 +4,19 @@
 {% set gtmJourney = "f2f - findAddress" %}
 
 {% from "hmpo-text/macro.njk" import hmpoText %}
-{% from "hmpo-form/macro.njk" import hmpoForm %}
-{% from "hmpo-date/macro.njk" import hmpoDate %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-
-
 
 {% block mainContent %}
-
-{% set title = translate("findAddress.title") %}
-{% set content = translate("findAddress.content") %}
-{% set prompt = translate("findAddress.prompt") %}
-{% set hintText = translate("findAddress.hintText") %}
-{% set formInstructions = "<p id=\"findAddressContent\">"+content+"</p><p>"+prompt+"</p>"+hintText+"<p>"%}
-
-<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
-    {{ title }}
-</h1>
+    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+        {{ translate("findAddress.title") }}
+    </h1>
     
-    {% call hmpoForm(ctx) %}
-          {{ hmpoText(ctx, {
-            id: "letterPostcode",
-            namePrefix: "letterPostcode",
-            fieldset: {
-                legend: {
-                    text: title,
-                    isPageHeading: true,
-                    classes: "govuk-fieldset__legend--l"
-                }
-            },
-            hint: {
-                html: formInstructions
-            }
-        }) }}
+    {% call hmpoForm(ctx, {attributes: {onsubmit: 'window.disableFormSubmit()'} }) %}
+
+    <p id="branchesInformation">{{ translate("findAddress.content") }}</p>
+
+    {{ hmpoText(ctx, {
+        id: "letterPostcode"
+    })}}
 
     {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
 


### PR DESCRIPTION
### What changed

- Added correct label HTML tag to input label on `post-office-customer-letter-find-address` page
- Updated URL on landing page
- Minor copy updates

### Why did it change

To ensure a consistent and accessible journey users

### Issue tracking

- [KIWI-2149](https://govukverify.atlassian.net/browse/KIWI-2149)

## Checklists

### Evidence
![image](https://github.com/user-attachments/assets/07269f28-5083-442d-9efd-93c17a56afcd)


[KIWI-2149]: https://govukverify.atlassian.net/browse/KIWI-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ