### PR TITLE
[KIWI-2155] - FE | Updating Postal address display in Check Details screen

### DIFF
--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -192,12 +192,12 @@ class CheckDetailsController extends DateController {
 
       // Assign values for display text and API payload
       req.sessionModel.set("pdfPreference", "EMAIL_ONLY");
-      if (req.sessionModel.get("postOfficeCustomerLetterChoice") == "email") {
+      if (req.sessionModel.get("postOfficeCustomerLetterChoice") === "email") {
         locals.pdfPreferenceText = res.locals.translate(
           "checkDetails.pdfPreferenceTextEmail"
         );
       } else if (
-        req.sessionModel.get("postOfficeCustomerLetterChoice") == "post"
+        req.sessionModel.get("postOfficeCustomerLetterChoice") === "post"
       ) {
         locals.pdfPreferenceText = res.locals.translate(
           "checkDetails.pdfPreferenceTextPcl"

--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -8,6 +8,7 @@ const {
 } = require("@govuk-one-login/frontend-passthrough-headers");
 const {
   generateHTMLofAddress,
+  titleCaseAddresses,
 } = require("../../../presenters/addressPresenter");
 
 class CheckDetailsController extends DateController {
@@ -180,7 +181,7 @@ class CheckDetailsController extends DateController {
           "differentAddress"
       ) {
         const displayAddress = generateHTMLofAddress(
-          req.sessionModel.get("postalAddress")
+          titleCaseAddresses(req.sessionModel.get("postalAddress"))
         );
         locals.addressLine = displayAddress;
       } else {

--- a/src/app/f2f/utils.js
+++ b/src/app/f2f/utils.js
@@ -47,24 +47,8 @@ function convertKeysToLowerCase(obj) {
   return obj;
 }
 
-function toTitleCase(str) {
-  return str.toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function formatAddress(address) {
-  const formattedAddress = {
-    line1: toTitleCase(address.building_number),
-    line2: toTitleCase(address.thoroughfare_name),
-    line3: toTitleCase(address.post_town),
-    postcode: address.postcode,
-  };
-  return formattedAddress;
-}
-
 module.exports = {
   formatDate,
   beforeNow,
   convertKeysToLowerCase,
-  toTitleCase,
-  formatAddress,
 };

--- a/src/app/f2f/utils.test.js
+++ b/src/app/f2f/utils.test.js
@@ -1,9 +1,4 @@
-const {
-  formatDate,
-  beforeNow,
-  convertKeysToLowerCase,
-  formatAddress,
-} = require("./utils");
+const { formatDate, beforeNow, convertKeysToLowerCase } = require("./utils");
 const { expect } = require("chai");
 const moment = require("moment");
 
@@ -71,42 +66,6 @@ describe("beforeNow", () => {
     });
 
     expect(validator(issueDate, 10, "years")).to.be.true;
-  });
-
-  describe("formatAddress", () => {
-    it("should format address correctly", () => {
-      const address = {
-        uprn: "11111",
-        udprn: "1111111",
-        address: "34, MOCK ROAD, PLACEHOLDER PARK, FAKESVILLE, FS6 5AQ",
-        building_number: "34",
-        thoroughfare_name: "MOCK ROAD",
-        dependent_locality: "PLACEHOLDER PARK",
-        post_town: "FAKESVILLE",
-        postcode: "FS6 5AQ",
-      };
-
-      const formattedAddress = formatAddress(address);
-      expect(formattedAddress).to.eql({
-        line1: "34",
-        line2: "Mock Road",
-        line3: "Fakesville",
-        postcode: "FS6 5AQ",
-      });
-    });
-  });
-});
-
-describe("convertKeysToLowerCase", () => {
-  it("should turn all uppercase item keys to lower case", () => {
-    const data = {
-      KEY1: "value1",
-      KEY2: "value2",
-      KEY3: "value3",
-    };
-
-    const convertedData = convertKeysToLowerCase(data);
-    expect(Object.keys(convertedData)).to.deep.equal(["key1", "key2", "key3"]);
   });
 });
 

--- a/src/presenters/addressPresenter.js
+++ b/src/presenters/addressPresenter.js
@@ -15,6 +15,7 @@ module.exports = {
       return `${fullBuildingName}, ${fullLocality}, ${address.postcode}`.trim();
     }
   },
+
   generateHTMLofAddress: function (address) {
     const { buildingNames, streetNames, localityNames } =
       extractAddressFields(address);
@@ -27,11 +28,40 @@ module.exports = {
 
     const fullLocality = localityNames.join(" ");
 
-    if (fullStreetName) {
-      return `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postcode}<br>`;
-    } else {
-      return `${fullBuildingName},<br>${fullLocality},<br>${address.postcode}<br>`;
+    let addressConfirm = [];
+
+    if (fullBuildingName) {
+      addressConfirm.push(fullBuildingName);
     }
+
+    if (fullStreetName) {
+      addressConfirm.push(fullStreetName);
+    }
+
+    if (fullLocality) {
+      addressConfirm.push(fullLocality);
+    }
+
+    if (address.postcode) {
+      addressConfirm.push(address.postcode);
+    }
+    return addressConfirm.join("<br>");
+  },
+
+  titleCaseAddresses: function (address) {
+    const titleCaseAddress = {};
+    for (let key in address) {
+      if (typeof address[key] === "string" && key !== "postcode") {
+        titleCaseAddress[key] = address[key].replace(
+          /\w\S*/g,
+          (text) =>
+            text.charAt(0).toUpperCase() + text.substring(1).toLowerCase()
+        );
+      } else {
+        titleCaseAddress[key] = address[key];
+      }
+    }
+    return titleCaseAddress;
   },
 };
 

--- a/src/presenters/addressPresenter.test.js
+++ b/src/presenters/addressPresenter.test.js
@@ -2,58 +2,72 @@ const { expect } = require("chai");
 const {
   generateSearchResultString,
   generateHTMLofAddress,
+  titleCaseAddresses,
 } = require("./addressPresenter");
 
-const address = {
+const userSelectedAddress = {
+  organisation_name: "A COMPANY",
+  department_name: "SOME DEPARTMENT",
+  building_name: "THAT BUILDING",
+  sub_building_name: "ROOM 5",
+  building_number: "1",
+  dependent_street_name: "OUTER STREET",
+  double_dependent_locality: "DOUBLE DEPENDENT TOWN",
+  dependent_locality: "DEPENDENT TOWN",
+  post_town: "TOWN",
+  postcode: "ABC 123",
+};
+
+const titleCasedAddress = {
   organisation_name: "A Company",
   department_name: "Some Department",
   building_name: "That Building",
   sub_building_name: "Room 5",
   building_number: "1",
-  dependent_street_name: "Outer street",
-  double_dependent_locality: "Double dependent town",
-  dependent_locality: "Dependent town",
+  dependent_street_name: "Outer Street",
+  double_dependent_locality: "Double Dependent Town",
+  dependent_locality: "Dependent Town",
   post_town: "Town",
   postcode: "ABC 123",
 };
 
-const addressWithStreet = {
-  ...address,
+const titleCasedAddressWithStreet = {
+  ...titleCasedAddress,
   thoroughfare_name: "Inner street",
 };
 
 const buildingText = [
-  address.department_name,
-  address.organisation_name,
-  address.sub_building_name,
-  address.building_name,
+  titleCasedAddress.department_name,
+  titleCasedAddress.organisation_name,
+  titleCasedAddress.sub_building_name,
+  titleCasedAddress.building_name,
 ].join(" ");
 
 const localityText = [
-  address.double_dependent_locality,
-  address.dependent_locality,
-  address.post_town,
+  titleCasedAddress.double_dependent_locality,
+  titleCasedAddress.dependent_locality,
+  titleCasedAddress.post_town,
 ].join(" ");
 
 describe("Generate search result string", () => {
   const streetText = [
     buildingText,
-    address.building_number,
-    address.dependent_street_name,
+    titleCasedAddress.building_number,
+    titleCasedAddress.dependent_street_name,
   ].join(" ");
 
   it("should generate search result string without street name", () => {
-    expect(generateSearchResultString(address)).to.equal(
-      [streetText, localityText, address.postcode].join(", ")
+    expect(generateSearchResultString(titleCasedAddress)).to.equal(
+      [streetText, localityText, titleCasedAddress.postcode].join(", ")
     );
   });
 
   it("should generate search result string with street name", () => {
-    expect(generateSearchResultString(addressWithStreet)).to.equal(
+    expect(generateSearchResultString(titleCasedAddressWithStreet)).to.equal(
       [
-        [streetText, addressWithStreet.thoroughfare_name].join(" "),
+        [streetText, titleCasedAddressWithStreet.thoroughfare_name].join(" "),
         localityText,
-        address.postcode,
+        titleCasedAddress.postcode,
       ].join(", ")
     );
   });
@@ -61,36 +75,80 @@ describe("Generate search result string", () => {
 
 describe("Generate HTML of address", () => {
   it("should generate HTML without street name", () => {
-    expect(generateHTMLofAddress(address)).to.equal(
-      [
-        [
-          buildingText,
-          [address.building_number, address.dependent_street_name].join(" "),
-        ].join("<br>"),
-        localityText,
-        address.postcode,
-      ]
-        .join(",<br>")
-        .concat("<br>")
-    );
-  });
-
-  it("should generate HTML with street name", () => {
-    expect(generateHTMLofAddress(addressWithStreet)).to.equal(
+    expect(generateHTMLofAddress(titleCasedAddress)).to.equal(
       [
         [
           buildingText,
           [
-            address.building_number,
-            address.dependent_street_name,
-            addressWithStreet.thoroughfare_name,
+            titleCasedAddress.building_number,
+            titleCasedAddress.dependent_street_name,
           ].join(" "),
         ].join("<br>"),
         localityText,
-        address.postcode,
-      ]
-        .join(",<br>")
-        .concat("<br>")
+        titleCasedAddress.postcode,
+      ].join("<br>")
     );
+  });
+
+  it("should generate HTML with street name", () => {
+    expect(generateHTMLofAddress(titleCasedAddressWithStreet)).to.equal(
+      [
+        [
+          buildingText,
+          [
+            titleCasedAddress.building_number,
+            titleCasedAddress.dependent_street_name,
+            titleCasedAddressWithStreet.thoroughfare_name,
+          ].join(" "),
+        ].join("<br>"),
+        localityText,
+        titleCasedAddress.postcode,
+      ].join("<br>")
+    );
+  });
+});
+
+describe("titleCaseAddresses", () => {
+  it("should title case addresses", () => {
+    expect(titleCaseAddresses(userSelectedAddress)).to.deep.equal(
+      titleCasedAddress
+    );
+  });
+
+  const testCases = [
+    { postCodeValue: "PoSt cOde" },
+    { postCodeValue: "PO51 CDE" },
+    { postCodeValue: "po51 cde" },
+  ];
+
+  it("should not title case postalCode field for postcode fields", () => {
+    testCases.forEach((testCase) => {
+      userSelectedAddress.postcode = testCase.postCodeValue;
+      titleCasedAddress.postcode = testCase.postCodeValue;
+      expect(titleCaseAddresses(userSelectedAddress)).to.deep.equal(
+        titleCasedAddress
+      );
+    });
+  });
+
+  it("should return empty string if address is empty", () => {
+    const returnedAddresses = titleCaseAddresses({});
+    expect(returnedAddresses).to.deep.equal({});
+  });
+
+  it("should not attempt to title case null fields", () => {
+    const returnedAddresses = titleCaseAddresses({ buildingName: null });
+    expect(returnedAddresses).to.deep.equal({ buildingName: null });
+  });
+
+  it("should not attempt to title case non string fields", () => {
+    const returnedAddresses = titleCaseAddresses({
+      buildingNumber: 1,
+      booleanField: true,
+    });
+    expect(returnedAddresses).to.deep.equal({
+      buildingNumber: 1,
+      booleanField: true,
+    });
   });
 });

--- a/test/browser/pages/landingPage.js
+++ b/test/browser/pages/landingPage.js
@@ -22,9 +22,7 @@ module.exports = class PlaywrightDevPage {
   }
 
   async getPostOfficeNumberOfDays() {
-    const numberOfDaysText = await this.page.textContent(
-      ".govuk-inset-text"
-    );
+    const numberOfDaysText = await this.page.textContent(".govuk-inset-text");
     return numberOfDaysText.trim();
   }
 

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -34,13 +34,16 @@ Then("they should be redirected to the Landing Page", async function () {
   expect(await landingPage.isCurrentPage()).to.be.true;
 });
 
-Then("the user should see they have 10 days to visit the Post Office", async function () {
-  const landingPage = new LandingPage(await this.page);
+Then(
+  "the user should see they have 10 days to visit the Post Office",
+  async function () {
+    const landingPage = new LandingPage(await this.page);
 
-  expect(await landingPage.checkPostOfficeNumberOfDays()).to.contain(
-    "10 days"
+    expect(await landingPage.checkPostOfficeNumberOfDays()).to.contain(
+      "10 days"
     );
-});
+  }
+);
 
 Then("they should be redirected to the Find a Branch page", async function () {
   const findBranchValid = new FindBranch(await this.page);

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -39,7 +39,7 @@ Then(
   async function () {
     const landingPage = new LandingPage(await this.page);
 
-    expect(await landingPage.checkPostOfficeNumberOfDays()).to.contain(
+    expect(await landingPage.getPostOfficeNumberOfDays()).to.contain(
       "10 days"
     );
   }


### PR DESCRIPTION
### What changed

Updated existing `toTitleCase` function to account for post codes and renamed to `titleCaseAddresses` + moved function location. Also removed unused `formatAddress` function and unused/duplicate unit tests.

### Why did it change

To display the users chosen address in the correct format

### Issue tracking

- [KIWI-2155](https://govukverify.atlassian.net/browse/KIWI-2155)

### Evidence
![image](https://github.com/user-attachments/assets/3ee226a0-a5c4-468b-b7e6-1432879141f6)



[KIWI-2155]: https://govukverify.atlassian.net/browse/KIWI-2155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ