### PR TITLE
[KIWI-2156]Updating Error messaging and Title styling on PCL screens

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -322,5 +322,5 @@ main p,
 #branchesInformation {
   color: govuk-colour("black");
   @include govuk-responsive-margin(3, "top");
-  @include govuk-responsive-margin(4, "bottom");
+  @include govuk-responsive-margin(5, "bottom");
 }

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -80,3 +80,4 @@ common:
 
 links:
   changePostcode: <span class="govuk-body govuk-!-font-size-24" data-id="changePostcodeValue"><b id="postcode">{{values.postcode}}</b></span> &nbsp;&nbsp;&nbsp; <a href="/find-post-office-prove-identity?edit=true" id="changePostcode" data-id="changePostcode" class="govuk-link"> Newid <span class="govuk-visually-hidden">eich cod post cyfredol</span></a>
+  changeLetterPostcode: <p>Cod post <br> <span class="govuk-body govuk-!-font-size-24" data-id="changeLetterPostcodeValue"><b id="letterPostcode">{{letterPostcode}}</b></span> &nbsp;&nbsp;&nbsp; <a href="/post-office-customer-letter-find-address?edit=true" id="changeLetterPostcode" data-id="changeLetterPostcode" class="govuk-link"> Newid <span class="govuk-visually-hidden">eich cod post cyfredol</span></a></p>

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -193,7 +193,7 @@ postcode:
     default: "Rhowch god post gwirioneddol yn y DU"
 
 letterPostcode:
-  label: Cod post y DU
+  label: Rhowch god post yn y DU
   hint: Er enghraifft, SW1A 2AA
   validation:
     default: "Rhowch god post llawn yn y DU"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -78,8 +78,7 @@ locations:
 
 addressResults:
   title: "Dewiswch gyfeiriad"
-  label: "Cod post"
-  prompt: "Dewiswch gyfeiriad o'r rhestr"
+  label: "Dewiswch gyfeiriad o'r rhestr"
   noAddress-summary: "Ni allaf ddod o hyd i'm cyfeiriad ar y rhestr"
   noAddress-link: "Os na allwch ddod o hyd i'ch cyfeiriad ar y rhestr, gallwch gael llythyr cwsmer Swyddfa'r Post drwy e-bost yn unig."
 

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -81,4 +81,4 @@ common:
 
 links:
   changePostcode: <span class="govuk-body govuk-!-font-size-24" data-id="changePostcodeValue"><b id="postcode">{{values.postcode}}</b></span> &nbsp;&nbsp;&nbsp; <a href="/find-post-office-prove-identity?edit=true" id="changePostcode" data-id="changePostcode" class="govuk-link"> Change <span class="govuk-visually-hidden">your current postcode</span></a>
-  changeLetterPostcode: <span class="govuk-body govuk-!-font-size-24" data-id="changeLetterPostcodeValue"><b id="letterPostcode">{{letterPostcode}}</b></span> &nbsp;&nbsp;&nbsp; <a href="/post-office-customer-letter-find-address?edit=true" id="changeLetterPostcode" data-id="changeLetterPostcode" class="govuk-link"> Change <span class="govuk-visually-hidden">your current postcode</span></a>
+  changeLetterPostcode: <p>Postcode <br><span class="govuk-body govuk-!-font-size-24" data-id="changeLetterPostcodeValue"><b id="letterPostcode">{{letterPostcode}}</b></span> &nbsp;&nbsp;&nbsp; <a href="/post-office-customer-letter-find-address?edit=true" id="changeLetterPostcode" data-id="changeLetterPostcode" class="govuk-link"> Change <span class="govuk-visually-hidden">your current postcode</span></a></p>

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -196,7 +196,7 @@ postcode:
     default: "Enter a real UK postcode"
 
 letterPostcode:
-  label: UK postcode
+  label: Enter a UK postcode
   hint: For example, SW1A 2AA
   validation:
     default: "Enter a full UK postcode"
@@ -447,7 +447,7 @@ countries:
     ZWE: "Zimbabwe"
 
 customerLetterCheckAddress:
-  validation: 
+  validation:
     required: "Select if you want your Post Office customer letter to be sent to this address"
   items:
     existingAddress:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -82,8 +82,7 @@ findAddress:
 
 addressResults:
   title: "Choose an address"
-  label: "Postcode"
-  prompt: "Choose an address from the list"
+  label: "Choose an address from the list"
   noAddress-summary: "I cannot find my address on the list"
   noAddress-link: <p>If you cannot find your address in the list, you can <a href="/post-office-customer-letter" class="govuk-link">get your Post Office customer letter by email only</a></p>
 

--- a/src/views/f2f/post-office-customer-letter-check-address.html
+++ b/src/views/f2f/post-office-customer-letter-check-address.html
@@ -2,44 +2,38 @@
 {# the content for this page is controlled by locales/en/default.yml #}
 {% set hmpoPageKey = "customerLetterCheckAddress" %}
 {% set gtmJourney = "f2f - customerLetterCheckAddress" %}
+
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "hmpo-radios/macro.njk" import hmpoRadios %}
-{% from "hmpo-form/macro.njk" import hmpoForm %}
 
 {% block mainContent %}
 
 {% set title = translate("customerLetterCheckAddress.title") %}
 {% set content = translate("customerLetterCheckAddress.content") %}
 {% set prompt = translate("customerLetterCheckAddress.prompt") %}
-{% set sharedClaimsAddress = "<p>"+addressLine+"</p>" %}
-{% set insetText = govukInsetText({
-    html: sharedClaimsAddress
-  }) %}
-{% set formInstructions = "<p class=\"addressCheckContent\">"+content+"</p><div>"+insetText+"</div><p class=\"addressCheckPrompt\">"+prompt+"</p>"%}
 
-      {% call hmpoForm(ctx) %}
-              {{ hmpoRadios(ctx, {
-                id: "customerLetterCheckAddress",
-                namePrefix: "customerLetterCheckAddress",
-                fieldset: {
-                    legend: {
-                        text: title,
-                        isPageHeading: true,
-                        classes: "govuk-fieldset__legend--l customerLetterCheckAddress-radios"
-                    }
-                },
-                hint: {
-                    html: formInstructions
+    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+        {{ title }}
+    </h1>
+
+    {% call hmpoForm(ctx) %}
+        <p class="addressCheckContent">{{ content }}</p>
+
+        {{ govukInsetText({
+            html: "<p>" + addressLine + "</p>"
+        }) }}
+
+        {{ hmpoRadios(ctx, {
+            id: "customerLetterCheckAddress",
+                legend: {
+                    text: prompt,
+                    classes: "govuk-fieldset__legend--m"
                 }
-            }) }}
+        })}}
 
-            {{ hmpoSubmit(ctx, {id: "continue", classes: "radioButtonsContinue", text: translate("buttons.next")}) }}
-
-            {% endcall %}
-
-{% endblock %} 
-  </div>
-</div>
+        {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.continue")}) }}
+    {% endcall %}
+{% endblock %}
 
 {% set footerNavItems = translate("govuk.footerNavItems") %}
 

--- a/src/views/f2f/post-office-customer-letter-choose-address.html
+++ b/src/views/f2f/post-office-customer-letter-choose-address.html
@@ -2,6 +2,7 @@
 {# the content for this page is controlled by locales/en/default.yml #}
 {% set hmpoPageKey = "addressResults" %}
 {% set gtmJourney = "f2f - addressResults" %}
+{% from "hmpo-form/macro.njk" import hmpoForm %}
 
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "hmpo-select/macro.njk" import hmpoSelect %}
@@ -9,26 +10,16 @@
 
 {% block mainContent %}
 
-{% set title = translate("addressResults.title") %}
-{% set userPostCodeLabel = translate("addressResults.label") %}
-{% set userPostCodeControl = hmpoHtml(translate("links.changeLetterPostcode")) %}
-{% set userPostCodePrompt = translate("addressResults.prompt") %}
-{% set formInstructions = "<p>"+userPostCodeControl+"</p><p class=\"govuk-!-margin-top-6\">"+userPostCodePrompt+"</p>" %}
+    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">{{ translate("addressResults.title") }}</h1>
 
-
-    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
-        {{ translate("addressResults.title") }}
-    </h1>
+    {{hmpoHtml(translate("links.changeLetterPostcode"))}}
 
     {% call hmpoForm(ctx) %}
 
         {{ hmpoSelect(ctx, {
             id: "addressResults",
-            name: "addressResults",
-            label: userPostCodeLabel,
-            hint: {
-                html: formInstructions
-            },
+            label: translate("addressResults.label"),
+            hint: "",
             items: addressResults
         }) }}
 

--- a/src/views/f2f/post-office-customer-letter.html
+++ b/src/views/f2f/post-office-customer-letter.html
@@ -4,7 +4,6 @@
 {% set gtmJourney = "f2f - postOfficeCustomerLetter" %}
 
 {% from "hmpo-radios/macro.njk" import hmpoRadios %}
-{% from "hmpo-form/macro.njk" import hmpoForm %}
 
 {% block mainContent %}
 
@@ -12,29 +11,29 @@
 {% set content1 = translate("postOfficeCustomerLetterChoice.content1") %}
 {% set content2 = translate("postOfficeCustomerLetterChoice.content2") %}
 {% set prompt = translate("postOfficeCustomerLetterChoice.prompt") %}
-{% set formInstructions = "<p id=\"contentLine1\">"+content1+"</p><p id=\"contentLine2\">"+content2+"</p><p class=\"postOfficeLetterPrompt\">"+prompt+"</p>"%}
-      
-      {% call hmpoForm(ctx) %}
-              {{ hmpoRadios(ctx, {
-                id: "postOfficeCustomerLetterChoice",
-                namePrefix: "postOfficeCustomerLetterChoice",
-                fieldset: {
-                    legend: {
-                        text: title,
-                        isPageHeading: true,
-                        classes: "govuk-fieldset__legend--l postOfficeCustomerLetterChoice-radios"
-                    }
-                },
-                hint: {
-                    html: formInstructions
-                }
-            }) }}
 
-    {{ hmpoSubmit(ctx, {id: "continue", classes: "radioButtonsContinue", text: translate("buttons.next")}) }}
-  
+    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+      {{ title }}
+    </h1>
+
+{% call hmpoForm(ctx) %}
+    <div id="branches-hint">
+      <p id="branchesInformation">{{ content1 }}</p>
+      <p>{{ content2 }}</p>
+    </div>
+
+        {{ hmpoRadios(ctx, {
+            id: "postOfficeCustomerLetterChoice",
+            legend: {
+                text: prompt,
+                classes: "govuk-fieldset__legend--m"
+            }
+        })}}
+
+        {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.continue")}) }}
     {% endcall %}
 
-{% endblock %} 
+{% endblock %}
 
 {% set footerNavItems = translate("govuk.footerNavItems") %}
 

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -39,9 +39,7 @@ Then(
   async function () {
     const landingPage = new LandingPage(await this.page);
 
-    expect(await landingPage.getPostOfficeNumberOfDays()).to.contain(
-      "10 days"
-    );
+    expect(await landingPage.getPostOfficeNumberOfDays()).to.contain("10 days");
   }
 );
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

## Evidence

### `Before`
<img width="400" src="https://github.com/user-attachments/assets/30b137bd-1c92-407d-8b92-bf08b864005b" />

### `After`
<img width="400" alt="Screenshot 2025-02-11 at 13 17 42" src="https://github.com/user-attachments/assets/67a5cc3d-1c46-4b84-8274-82622da4123f" />

---

### `Before`
<img width="400" src="https://github.com/user-attachments/assets/e0a25b9a-7965-4f4b-afeb-ed59763068c5" />

### `After`
<img width="400" alt="Screenshot 2025-02-11 at 13 20 06" src="https://github.com/user-attachments/assets/dad8e663-02e7-45f7-a224-021f6bdb8ea7" />

---
### `Before`
<img width="400" src="https://github.com/user-attachments/assets/6673e7f7-48f6-4af0-a2ec-a7bf5f605b06" />

### `After`
<img width="400" alt="Screenshot 2025-02-11 at 13 19 03" src="https://github.com/user-attachments/assets/2794a102-34ba-4054-8380-e9708bfe077b" />


