### PR TITLE
[KIWI-XXXX] - Added check for sessionId and additional log in root controller

### DIFF
--- a/src/app/f2f/controllers/root.js
+++ b/src/app/f2f/controllers/root.js
@@ -54,18 +54,22 @@ class RootController extends BaseController {
   }
 
   async getAddressInfo(axios, req) {
-    const tokenId = req.session.tokenId;
+    if (req.session) {
+      const tokenId = req.session.tokenId;
 
-    if (tokenId) {
-      const headers = {
-        "x-govuk-signin-session-id": tokenId,
-      };
-      const res = await axios.get(`${API.PATHS.PERSON_INFO}`, {
-        headers,
-      });
-      return res.data;
+      if (tokenId) {
+        const headers = {
+          "x-govuk-signin-session-id": tokenId,
+        };
+        const res = await axios.get(`${API.PATHS.PERSON_INFO}`, {
+          headers,
+        });
+        return res.data;
+      } else {
+        throw new Error("Missing sessionID", error);
+      }
     } else {
-      logger.error("Missing sessionID");
+      throw new Error("Missing session", error);
     }
   }
 

--- a/src/app/f2f/controllers/root.js
+++ b/src/app/f2f/controllers/root.js
@@ -37,10 +37,6 @@ class RootController extends BaseController {
           fullParsedSharedClaimsAddress
         );
 
-        // req.sessionModel.set("addressLine1", parsedAddress["address_line1"]);
-        // req.sessionModel.set("addressLine2", parsedAddress["address_line2"]);
-        // req.sessionModel.set("townCity", parsedAddress["town_city"]);
-        // req.sessionModel.set("postalCode", parsedAddress["postal_code"]);
         req.sessionModel.set("addressProcessed", true);
       } catch (error) {
         logger.error("Error calling /person-info", error);
@@ -58,13 +54,19 @@ class RootController extends BaseController {
   }
 
   async getAddressInfo(axios, req) {
-    const headers = {
-      "x-govuk-signin-session-id": req.session.tokenId,
-    };
-    const res = await axios.get(`${API.PATHS.PERSON_INFO}`, {
-      headers,
-    });
-    return res.data;
+    const tokenId = req.session.tokenId;
+
+    if (tokenId) {
+      const headers = {
+        "x-govuk-signin-session-id": tokenId,
+      };
+      const res = await axios.get(`${API.PATHS.PERSON_INFO}`, {
+        headers,
+      });
+      return res.data;
+    } else {
+      logger.error("Missing sessionID");
+    }
   }
 
   async getDecryptKey(axios) {


### PR DESCRIPTION
### What changed

Added check for sessionId in root controller axios call and log

### Why did it change

Seeing a large number of failed Axios calls in the F2F FE, suspicion is that these are users with missing session Id

![image](https://github.com/user-attachments/assets/3e6dd923-f424-4dd5-8d71-343664bca9f8)
