### PR TITLE
[KIWI-2020] - | CM | Set minimum container count for initial scaling load

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -36,14 +36,6 @@ Parameters:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
     Default: "none"
-  MaxContainerCount:
-    Description: Maximum number of FE node/express container tasks to allow autoscaling to reach
-    Type: Number
-    Default: 12
-  MinContainerCount:
-    Description: Minimum number of FE node/express container tasks to allow autoscaling to reach
-    Type: Number
-    Default: 3
   EnableScalingInDev:
     Type: Number
     Default: 0
@@ -415,7 +407,7 @@ Resources:
           - UseCanaryDeployment
           - CODE_DEPLOY
           - ECS
-      DesiredCount: !Ref MinContainerCount
+      DesiredCount: !FindInMap [EnvironmentVariables, !Ref Environment, minECSCount]
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
@@ -1301,7 +1293,7 @@ Resources:
       Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 5
-      Threshold: !Ref MaxContainerCount
+      Threshold: [EnvironmentVariables, !Ref Environment, maxECSCount]
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       Metrics:

--- a/template.yaml
+++ b/template.yaml
@@ -153,6 +153,8 @@ Mappings:
       PROXYURL: "f2f-cri-outbound-proxy-proxy.review-o.dev.account.gov.uk"
       LOGLEVEL: "debug"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 1
+      maxECSCount: 4
     build:
       APIBASEURL: "https://api.review-o.build.account.gov.uk"
       DNSSUFFIX: "review-o.build.account.gov.uk"
@@ -165,6 +167,8 @@ Mappings:
       PROXYURL: "proxy.review-o.build.account.gov.uk"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 6
+      maxECSCount: 60
     staging:
       APIBASEURL: "https://api.review-o.staging.account.gov.uk"
       DNSSUFFIX: "review-o.staging.account.gov.uk"
@@ -177,6 +181,8 @@ Mappings:
       PROXYURL: "proxy.review-o.staging.account.gov.uk"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 2
+      maxECSCount: 4
     integration:
       APIBASEURL: "https://api.review-o.integration.account.gov.uk"
       DNSSUFFIX: "review-o.integration.account.gov.uk"
@@ -189,6 +195,8 @@ Mappings:
       PROXYURL: "proxy.review-o.integration.account.gov.uk"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 2
+      maxECSCount: 4
     production:
       APIBASEURL: "https://api.review-o.account.gov.uk"
       DNSSUFFIX: "review-o.account.gov.uk"
@@ -201,6 +209,8 @@ Mappings:
       PROXYURL: "proxy.review-o.account.gov.uk"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 6
+      maxECSCount: 60
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -896,8 +906,10 @@ Resources:
     Condition: EnableScaling
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: !Ref MaxContainerCount
-      MinCapacity: !Ref MinContainerCount
+      MinCapacity:
+        !FindInMap [EnvironmentVariables, !Ref Environment, minECSCount]
+      MaxCapacity:
+        !FindInMap [EnvironmentVariables, !Ref Environment, maxECSCount]
       ResourceId: !Join
         - '/'
         - - "service"


### PR DESCRIPTION
### What changed

Set minimum and maximum containers for each environment

### Why did it change

Allow the service to scale appropriately. Capacity is higher in build and production where we do perf tests

- [KIWI-2020](https://govukverify.atlassian.net/browse/KIWI-2020)
