### PR TITLE
IPS-1407: Migrate WAF in F2F CRI to FMS

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -147,37 +147,37 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 704
+        "line_number": 707
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 706
+        "line_number": 709
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 707
+        "line_number": 710
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 710
+        "line_number": 713
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 712
+        "line_number": 715
       }
     ]
   },
-  "generated_at": "2025-04-11T12:43:00Z"
+  "generated_at": "2025-04-14T09:49:23Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -323,6 +323,9 @@ Resources:
           - Key: routing.http.drop_invalid_header_fields.enabled
             Value: true
         - !Ref AWS::NoValue
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: false
 
   LoadBalancerListenerTargetGroupECS:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'


### PR DESCRIPTION
## Proposed changes
- Added tags to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed
- Added tags to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF
<!-- Describe the changes in detail - the "what"-->

### Why did it change
- Added tags to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1407](https://govukverify.atlassian.net/browse/IPS-1407)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[IPS-1407]: https://govukverify.atlassian.net/browse/IPS-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ