### PR TITLE
[KIWI-2318] - DI | Set Cookie domain for all environments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -147,37 +147,37 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 707
+        "line_number": 714
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 709
+        "line_number": 716
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 710
+        "line_number": 717
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 713
+        "line_number": 720
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 715
+        "line_number": 722
       }
     ]
   },
-  "generated_at": "2025-04-14T09:49:23Z"
+  "generated_at": "2025-05-22T11:40:16Z"
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -109,7 +109,7 @@ module.exports = {
     },
     LANGUAGE_TOGGLE_DISABLED: process.env.LANGUAGE_TOGGLE_DISABLED || true,
     DEVICE_INTELLIGENCE_ENABLED: process.env.DEVICE_INTELLIGENCE_ENABLED || false,
-    DEVICE_INTELLIGENCE_DOMAIN: process.env.FRONTEND_DOMAIN || "localhost",
+    DEVICE_INTELLIGENCE_DOMAIN: process.env.DEVICE_INTELLIGENCE_DOMAIN || "localhost",
   },
   PORT: process.env.PORT || 5030,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/template.yaml
+++ b/template.yaml
@@ -142,6 +142,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "true"
       ANALYTICSDOMAIN: "dev.account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       PROXYURL: "f2f-cri-outbound-proxy-proxy.review-o.dev.account.gov.uk"
       LOGLEVEL: "debug"
       LANGUAGETOGGLEDISABLED: false
@@ -157,6 +158,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "true"
       ANALYTICSDOMAIN: "build.account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       PROXYURL: "proxy.review-o.build.account.gov.uk"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
@@ -172,6 +174,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "true"
       ANALYTICSDOMAIN: "staging.account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       PROXYURL: "proxy.review-o.staging.account.gov.uk"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
@@ -187,6 +190,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "false"
       ANALYTICSDOMAIN: "integration.account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       PROXYURL: "proxy.review-o.integration.account.gov.uk"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
@@ -202,6 +206,7 @@ Mappings:
       GTMIDGA4: "GTM-K4PBJH3"
       GA4ENABLED: "false"
       ANALYTICSDOMAIN: "account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       PROXYURL: "proxy.review-o.account.gov.uk"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
@@ -608,6 +613,8 @@ Resources:
                   "account.gov.uk",
                   !Sub "${Environment}.account.gov.uk"
                 ]
+            - Name: DEVICE_INTELLIGENCE_DOMAIN
+              Value: !FindInMap [ EnvironmentVariables, !Ref Environment, DEVICEINTELLIGENCEDOMAIN ]
             - Name: PROXYURL
               Value: !FindInMap [EnvironmentVariables, !Ref Environment, PROXYURL ]
             - Name: LOG_LEVEL


### PR DESCRIPTION
### What changed

Set device intelligence cookie domain to account.gov.uk across all envs

### Why did it change

To address issue with header size stemming from environment specific domain names

### Issue tracking

- [KIWI-2318](https://govukverify.atlassian.net/browse/KIWI-2318)

![Screenshot 2025-05-22 at 13 06 37](https://github.com/user-attachments/assets/21a73f2d-e04b-43d8-a0ad-c781c7e120a6)



[KIWI-2318]: https://govukverify.atlassian.net/browse/KIWI-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ