### PR TITLE
[KIWI-2251] - | FE | Enable feature flag for Device Intelligence in INT and PROD

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -180,7 +180,7 @@ Mappings:
       LANGUAGETOGGLEDISABLED: false
       minECSCount: 2
       maxECSCount: 4
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
     integration:
       APIBASEURL: "https://api.review-o.integration.account.gov.uk"
       DNSSUFFIX: "review-o.integration.account.gov.uk"
@@ -196,7 +196,7 @@ Mappings:
       LANGUAGETOGGLEDISABLED: false
       minECSCount: 2
       maxECSCount: 4
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
     production:
       APIBASEURL: "https://api.review-o.account.gov.uk"
       DNSSUFFIX: "review-o.account.gov.uk"
@@ -212,7 +212,7 @@ Mappings:
       LANGUAGETOGGLEDISABLED: false
       minECSCount: 6
       maxECSCount: 60
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
 
 Resources:
   # Security Groups for the ECS service and load balancer


### PR DESCRIPTION
### What changed

Turned on Device Intelligence in staging, integration and production

### Why did it change

To enable the program to collect collection and analysis of data from end user devices and satisfy HMRC Day2 Must Have requirements

### Issue tracking

- [KIWI-2251](https://govukverify.atlassian.net/browse/KIWI-2251)


[KIWI-2251]: https://govukverify.atlassian.net/browse/KIWI-2251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ